### PR TITLE
feat/client: basic user management page with static data using MUI table

### DIFF
--- a/client/src/components/BtnCrud.tsx
+++ b/client/src/components/BtnCrud.tsx
@@ -1,0 +1,59 @@
+import { Button } from "@mui/material";
+import DeleteIcon from "@mui/icons-material/Delete";
+import AddIcon from "@mui/icons-material/Add";
+import SaveIcon from "@mui/icons-material/Save";
+import EditIcon from "@mui/icons-material/Edit";
+import CloseIcon from "@mui/icons-material/Close";
+import { BtnCrudType } from "../types/BtnCrudType";
+
+// This button is used to handle CRUD actions
+// it has 5 display modes, try them out with the type prop
+export default function BtnCrud({
+  type,
+  disabled = false,
+  handleClick,
+}: BtnCrudType) {
+  const colorMap: { [key: string]: "success" | "error" | "primary" } = {
+    edit: "primary",
+    delete: "error",
+    add: "primary",
+    save: "success",
+    cancel: "error",
+  };
+
+  const innerTextMap: { [key: string]: string } = {
+    edit: "EDITER",
+    delete: "SUPPRIMER",
+    add: "AJOUTER",
+    save: "SAUVEGARDER",
+    cancel: "ANNULER",
+  };
+
+  const iconMap = {
+    edit: <EditIcon />,
+    delete: <DeleteIcon />,
+    add: <AddIcon />,
+    save: <SaveIcon />,
+    cancel: <CloseIcon />,
+  };
+
+  const variantMap: { [key: string]: "contained" | "outlined" } = {
+    edit: "outlined",
+    delete: "outlined",
+    add: "contained",
+    save: "contained",
+    cancel: "outlined",
+  };
+
+  return (
+    <Button
+      color={colorMap[type]}
+      disabled={disabled}
+      variant={variantMap[type]}
+      onClick={handleClick}
+      startIcon={iconMap[type]}
+    >
+      {innerTextMap[type]}
+    </Button>
+  );
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { createBrowserRouter, RouterProvider, Outlet } from "react-router-dom";
 import App from "./App.tsx";
+import ManageUser from "./pages/administrator/user/ManageUser.tsx";
 
 const router = createBrowserRouter([
   {
@@ -17,8 +18,14 @@ const router = createBrowserRouter([
         element: <Outlet />,
         children: [
           {
-            index: true,
-            element: <h1>Administrateur</h1>,
+            path: "user",
+            element: <Outlet />,
+            children: [
+              {
+                index: true,
+                element: <ManageUser />,
+              },
+            ],
           },
         ],
       },

--- a/client/src/pages/administrator/user/ManageUser.tsx
+++ b/client/src/pages/administrator/user/ManageUser.tsx
@@ -1,0 +1,77 @@
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Paper from "@mui/material/Paper";
+import Stack from "@mui/material/Stack";
+import BtnCrud from "../../../components/BtnCrud";
+
+function createData(
+  id: number,
+  firstname: string,
+  lastname: string,
+  email: string,
+) {
+  return { id, firstname, lastname, email };
+}
+
+const rows = [
+  createData(1, "Toto", "Tata", "toto@tata.org"),
+  createData(2, "Jean-Claude", "Octave", "jean@claude.net"),
+  createData(3, "Eclair", "Chocolat", "eclair@chocolat.net"),
+  createData(4, "Ashitaka", "Ghibli", "ashitaka@ghibli.net"),
+  createData(5, "Severus", "Snape", "severus@snape.net"),
+];
+
+export default function ManageUser() {
+  return (
+    <div>
+      <h1>Gestion des utilisateurs</h1>
+
+      <TableContainer component={Paper}>
+        <Table sx={{ minWidth: 650 }} aria-label="Tableau des utilisateurs">
+          <TableHead>
+            <TableRow>
+              <TableCell>#</TableCell>
+              <TableCell align="left">Nom</TableCell>
+              <TableCell align="left">Prénom</TableCell>
+              <TableCell align="left">Email</TableCell>
+              <TableCell align="left"></TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows.map((row) => (
+              <TableRow
+                key={row.id}
+                sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
+              >
+                <TableCell component="th" scope="row">
+                  {row.id}
+                </TableCell>
+                <TableCell align="left">{row.firstname}</TableCell>
+                <TableCell align="left">{row.lastname}</TableCell>
+                <TableCell align="left">{row.email}</TableCell>
+                <TableCell align="left">
+                  <Stack spacing={2} direction="row">
+                    <BtnCrud
+                      disabled={false}
+                      handleClick={() => null}
+                      type={"edit"}
+                    />
+                    <BtnCrud
+                      disabled={false}
+                      handleClick={() => null}
+                      type={"delete"}
+                    />
+                  </Stack>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </div>
+  );
+}

--- a/client/src/types/BtnCrudType.ts
+++ b/client/src/types/BtnCrudType.ts
@@ -1,0 +1,5 @@
+export type BtnCrudType = {
+  type: "add" | "edit" | "delete" | "save" | "cancel";
+  disabled?: boolean;
+  handleClick: () => void;
+};


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/57088097-9259-4e2d-ad7d-d632f14a1366)

- user management page (with static data)
- using MUI table component
- added a BtnCrud component to handle CRUD actions