### PR TITLE
S4 us92 homepage

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,8 +1,9 @@
-import { Outlet } from "react-router";
+import { Outlet, useLocation } from "react-router";
 import Header from "./components/header/Header";
 import Footer from "./components/footer/Footer";
 import Container from "@mui/material/Container";
 import MenuSideBar from "./components/menuSideBar/MenuSideBar";
+import Home from "./pages/Home";
 import { createTheme, ThemeProvider } from "@mui/material/styles";
 import { Toolbar } from "@mui/material";
 import { Grid2 } from "@mui/material";
@@ -29,7 +30,7 @@ const theme = createTheme({
     },
     secondary: {
       main: "#DADBBD", // Yellow
-      contrastText: "#FFFFFF",
+      contrastText: "#00235B",
     },
     success: {
       main: "#6EBF8B", // Green
@@ -52,28 +53,38 @@ const theme = createTheme({
 });
 
 function App() {
+  const location = useLocation();
+  const currentPage = location.pathname;
+
   return (
     <>
       <ThemeProvider theme={theme}>
-        <Header
-          title="ClubCompta"
-          subtitle="Budget 2024/2025"
-          userType="Responsable"
-          logoUrl="/Logo.svg"
-          avatarColor="#6EBF8B"
-        />
-        <Toolbar />
-        <Container maxWidth="xl">
-          <Grid2 container spacing={2}>
-            <Grid2 size={2} sx={{ backgroundColor: "#f3f3f3" }}>
-              <MenuSideBar />
-            </Grid2>
-            <Grid2 size={10}>
-              <Outlet />
-            </Grid2>
-          </Grid2>
-          <Footer />
-        </Container>
+        {currentPage !== "/" ? (
+          <>
+            <Header
+              title="ClubCompta"
+              subtitle="Budget 2024/2025"
+              userType="Responsable"
+              logoUrl="/Logo.svg"
+              avatarColor="#6EBF8B"
+            />
+            <Toolbar />
+
+            <Container maxWidth="xl">
+              <Grid2 container spacing={2}>
+                <Grid2 size={2} sx={{ backgroundColor: "#f3f3f3" }}>
+                  <MenuSideBar />
+                </Grid2>
+                <Grid2 size={10}>
+                  <Outlet />
+                </Grid2>
+              </Grid2>
+              <Footer />
+            </Container>
+          </>
+        ) : (
+          <Home />
+        )}
       </ThemeProvider>
     </>
   );

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -22,13 +22,13 @@ const theme = createTheme({
   },
   palette: {
     primary: {
-      main: "#D9D9D9", // Gray
+      main: "#00235B", // Blue
       // light: will be calculated from palette.primary.main,
       // dark: will be calculated from palette.primary.main,
-      contrastText: "#FFFFFF",
+      contrastText: "#F5F5F5",
     },
     secondary: {
-      main: "#FFDD83", // Yellow
+      main: "#DADBBD", // Yellow
       contrastText: "#FFFFFF",
     },
     success: {

--- a/client/src/components/BtnLink.tsx
+++ b/client/src/components/BtnLink.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { Link as MuiLink, LinkProps as MuiLinkProps } from "@mui/material";
+import { styled } from "@mui/system";
+import {
+  Link as RouterLink,
+  LinkProps as RouterLinkProps,
+} from "react-router-dom";
+
+interface StyledLinkProps extends MuiLinkProps {
+  href?: string; // URL for external links
+  to?: RouterLinkProps["to"]; // Path for internal routing
+}
+
+const StyledLinkRoot = styled(MuiLink)(({ theme }) => ({
+  textDecoration: "none", // Removes underline
+  color: theme.palette.primary.main, // Primary color
+  fontWeight: "bold", // Bold text
+  transition: "color 0.3s ease", // Smooth transition
+  "&:hover": {
+    textDecoration: "underline", // Underline on hover
+    color: theme.palette.secondary.main, // Hover color
+  },
+}));
+
+/**
+ * StyledLink Component
+ * A reusable link component for external and internal navigation.
+ *
+ * @param {StyledLinkProps} props - Props for the StyledLink component.
+ * @returns {JSX.Element} Styled link element.
+ */
+const BtnLink: React.FC<StyledLinkProps> = ({
+  href,
+  to,
+  children,
+  ...otherProps
+}) => {
+  const linkProps = to ? { component: RouterLink, to } : { href };
+
+  return (
+    <StyledLinkRoot {...linkProps} {...otherProps}>
+      {children}
+    </StyledLinkRoot>
+  );
+};
+
+export default BtnLink;

--- a/client/src/components/BtnLink.tsx
+++ b/client/src/components/BtnLink.tsx
@@ -12,18 +12,17 @@ interface StyledLinkProps extends MuiLinkProps {
 }
 
 const StyledLinkRoot = styled(MuiLink)(({ theme }) => ({
-  textDecoration: "none", // Removes underline
-  color: theme.palette.primary.main, // Primary color
-  fontWeight: "bold", // Bold text
-  transition: "color 0.3s ease", // Smooth transition
+  textDecoration: "none",
+  color: theme.palette.primary.main,
+  fontWeight: "bold",
   "&:hover": {
-    textDecoration: "underline", // Underline on hover
-    color: theme.palette.secondary.main, // Hover color
+    textDecoration: "underline",
+    color: theme.palette.secondary.main,
   },
 }));
 
 /**
- * StyledLink Component
+ * BtnLink Component
  * A reusable link component for external and internal navigation.
  *
  * @param {StyledLinkProps} props - Props for the StyledLink component.

--- a/client/src/components/header/Header.tsx
+++ b/client/src/components/header/Header.tsx
@@ -7,6 +7,7 @@ import Box from "@mui/material/Box";
 import Avatar from "../avatar/Avatar";
 import { useTheme } from "@mui/material/styles";
 import "./Header.css";
+import { Link } from "react-router-dom";
 
 interface HeaderProps {
   title: string;
@@ -34,7 +35,7 @@ const Header: React.FC<HeaderProps> = ({
   const avatarColor = roleColorMapping[userType || "default"];
 
   return (
-    <AppBar position="fixed">
+    <AppBar position="fixed" color="secondary">
       <Container maxWidth="xl">
         <Toolbar
           disableGutters
@@ -59,7 +60,7 @@ const Header: React.FC<HeaderProps> = ({
                   display: { xs: "none", sm: "block" }, // Masked on mobile (xs) and displayed for sm +
                 }}
               >
-                {title}
+                <Link to="/">{title}</Link>
               </Typography>
               {(subtitle || userType) && (
                 <Typography variant="h2" className="header-subtitle">

--- a/client/src/components/header/Header.tsx
+++ b/client/src/components/header/Header.tsx
@@ -60,7 +60,15 @@ const Header: React.FC<HeaderProps> = ({
                   display: { xs: "none", sm: "block" }, // Masked on mobile (xs) and displayed for sm +
                 }}
               >
-                <Link to="/">{title}</Link>
+                <Link
+                  to="/"
+                  style={{
+                    textDecoration: "none",
+                    color: theme.palette.primary.main,
+                  }}
+                >
+                  {title}
+                </Link>
               </Typography>
               {(subtitle || userType) && (
                 <Typography variant="h2" className="header-subtitle">

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -9,6 +9,8 @@ import ManageUser from "./pages/administrator/user/ManageUser.tsx";
 import HomePageCommission from "./pages/homePageCommission/HomePageCommission.tsx";
 import ManageCategory from "./pages/accountant/category/ManageCategory.tsx";
 import Invoice from "./pages/commission/Invoice.tsx";
+import Home from "./pages/Home.tsx";
+import Administrator from "./pages/administrator/Administrator.tsx";
 
 const router = createBrowserRouter([
   {
@@ -18,12 +20,16 @@ const router = createBrowserRouter([
     children: [
       {
         index: true,
-        element: <h1>Home page</h1>,
+        element: <Home />,
       },
       {
         path: "administrator",
         element: <Outlet />,
         children: [
+          {
+            index: true,
+            element: <Administrator />,
+          },
           {
             path: "user",
             element: <Outlet />,

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,0 +1,36 @@
+import Box from "@mui/material/Box";
+import Stack from "@mui/material/Stack";
+import BtnLink from "../components/BtnLink";
+
+const buttonStyle = {
+  display: "inline-block",
+  marginLeft: "auto",
+  backgroundColor: "primary.main",
+  padding: "8px 16px",
+  color: "primary.contrastText",
+  textTransform: "uppercase",
+  borderRadius: "4px",
+  textDecoration: "none",
+  textAlign: "center",
+  "&:hover": {
+    backgroundColor: "primary.dark",
+  },
+};
+
+export default function Home() {
+  return (
+    <Box sx={{ marginTop: "1em" }}>
+      <Stack spacing={2}>
+        <BtnLink to="/administrator" sx={buttonStyle}>
+          Administrateur
+        </BtnLink>
+        <BtnLink to="/accountant" sx={buttonStyle}>
+          Comptable
+        </BtnLink>
+        <BtnLink to="/commission" sx={buttonStyle}>
+          Responsable de commission
+        </BtnLink>
+      </Stack>
+    </Box>
+  );
+}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,36 +1,84 @@
 import Box from "@mui/material/Box";
 import Stack from "@mui/material/Stack";
 import BtnLink from "../components/BtnLink";
+import { Button, TextField, Typography } from "@mui/material";
+import logo from "/Logo_seul.svg";
 
 const buttonStyle = {
   display: "inline-block",
   marginLeft: "auto",
-  backgroundColor: "primary.main",
   padding: "8px 16px",
-  color: "primary.contrastText",
+  backgroundColor: "secondary.main",
+  color: "secondary.contrastText",
   textTransform: "uppercase",
   borderRadius: "4px",
   textDecoration: "none",
   textAlign: "center",
   "&:hover": {
-    backgroundColor: "primary.dark",
+    textDecoration: "none",
+    backgroundColor: "primary.light",
+    color: "secondary.main",
   },
 };
 
 export default function Home() {
   return (
-    <Box sx={{ marginTop: "1em" }}>
-      <Stack spacing={2}>
-        <BtnLink to="/administrator" sx={buttonStyle}>
-          Administrateur
-        </BtnLink>
-        <BtnLink to="/accountant" sx={buttonStyle}>
-          Comptable
-        </BtnLink>
-        <BtnLink to="/commission" sx={buttonStyle}>
-          Responsable de commission
-        </BtnLink>
-      </Stack>
-    </Box>
+    <>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          height: "100vh",
+        }}
+      >
+        <img src={logo} alt="ClubCompta" style={{ marginBottom: "20px" }} />
+        <Typography variant="h4" component="h2">
+          Connexion ClubCompta
+        </Typography>
+        <Box sx={{ mt: 3 }}>
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            id="email"
+            label="Adresse Email"
+            name="email"
+            autoComplete="email"
+            autoFocus
+          />
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            name="password"
+            label="Mot de passe"
+            type="password"
+            id="password"
+          />
+          <Button
+            type="submit"
+            fullWidth
+            variant="contained"
+            sx={{ mt: 3, mb: 2 }}
+          >
+            Se connecter
+          </Button>
+        </Box>
+
+        <Stack spacing={2} sx={{ marginTop: "4em" }}>
+          <BtnLink to="/administrator" sx={buttonStyle}>
+            Administrateur
+          </BtnLink>
+          <BtnLink to="/accountant" sx={buttonStyle}>
+            Comptable
+          </BtnLink>
+          <BtnLink to="/commission" sx={buttonStyle}>
+            Responsable de commission
+          </BtnLink>
+        </Stack>
+      </Box>
+    </>
   );
 }

--- a/client/src/pages/administrator/Administrator.tsx
+++ b/client/src/pages/administrator/Administrator.tsx
@@ -1,0 +1,34 @@
+import Box from "@mui/material/Box";
+import Stack from "@mui/material/Stack";
+import BtnLink from "../../components/BtnLink";
+
+export default function Administrator() {
+  return (
+    <>
+      <h1>Accès administrateur</h1>
+      <Box>
+        <Stack spacing={2}>
+          <BtnLink
+            to="/administrator/user"
+            sx={{
+              display: "inline-block",
+              marginLeft: "auto",
+              backgroundColor: "primary.main",
+              padding: "8px 16px",
+              color: "primary.contrastText",
+              textTransform: "uppercase",
+              borderRadius: "4px",
+              textDecoration: "none",
+              textAlign: "center",
+              "&:hover": {
+                backgroundColor: "primary.dark",
+              },
+            }}
+          >
+            Gestion des utilisateurs
+          </BtnLink>
+        </Stack>
+      </Box>
+    </>
+  );
+}

--- a/client/src/pages/administrator/Administrator.tsx
+++ b/client/src/pages/administrator/Administrator.tsx
@@ -1,4 +1,3 @@
-import Box from "@mui/material/Box";
 import Stack from "@mui/material/Stack";
 import BtnLink from "../../components/BtnLink";
 
@@ -6,29 +5,27 @@ export default function Administrator() {
   return (
     <>
       <h1>Accès administrateur</h1>
-      <Box>
-        <Stack spacing={2}>
-          <BtnLink
-            to="/administrator/user"
-            sx={{
-              display: "inline-block",
-              marginLeft: "auto",
-              backgroundColor: "primary.main",
-              padding: "8px 16px",
-              color: "primary.contrastText",
-              textTransform: "uppercase",
-              borderRadius: "4px",
-              textDecoration: "none",
-              textAlign: "center",
-              "&:hover": {
-                backgroundColor: "primary.dark",
-              },
-            }}
-          >
-            Gestion des utilisateurs
-          </BtnLink>
-        </Stack>
-      </Box>
+      <Stack spacing={2}>
+        <BtnLink
+          to="/administrator/user"
+          sx={{
+            display: "inline-block",
+            marginLeft: "auto",
+            backgroundColor: "primary.main",
+            padding: "8px 16px",
+            color: "primary.contrastText",
+            textTransform: "uppercase",
+            borderRadius: "4px",
+            textDecoration: "none",
+            textAlign: "center",
+            "&:hover": {
+              backgroundColor: "primary.dark",
+            },
+          }}
+        >
+          Gestion des utilisateurs
+        </BtnLink>
+      </Stack>
     </>
   );
 }

--- a/client/src/pages/administrator/user/ManageUser.tsx
+++ b/client/src/pages/administrator/user/ManageUser.tsx
@@ -8,6 +8,8 @@ import TableRow from "@mui/material/TableRow";
 import Paper from "@mui/material/Paper";
 import Stack from "@mui/material/Stack";
 import BtnCrud from "../../../components/BtnCrud";
+import { Box } from "@mui/material";
+import BtnLink from "../../../components/BtnLink";
 
 export default function ManageUser() {
   const { loading, error, data } = useGetUsersQuery();
@@ -18,6 +20,34 @@ export default function ManageUser() {
   return (
     <div>
       <h1>Gestion des utilisateurs</h1>
+
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+        }}
+      >
+        <div>Left Element</div>
+        <BtnLink
+          to="/administrator/user/add"
+          sx={{
+            display: "inline-block",
+            marginLeft: "auto",
+            backgroundColor: "primary.main",
+            padding: "8px 16px",
+            color: "primary.contrastText",
+            textTransform: "uppercase",
+            borderRadius: "4px",
+            textDecoration: "none",
+            textAlign: "center",
+            "&:hover": {
+              backgroundColor: "primary.dark",
+            },
+          }}
+        >
+          Ajouter un utilisateur
+        </BtnLink>
+      </Box>
 
       <TableContainer component={Paper}>
         <Table sx={{ minWidth: 650 }} aria-label="Tableau des utilisateurs">


### PR DESCRIPTION
- Added a login page :
![image](https://github.com/user-attachments/assets/9141894d-bce3-474f-a832-cd02fcfa4358)

- Modified App.tsx to  display the login page
- Added quick links used for dev only (to be removed when auth will be working)
- Fixed partially the color palette, primary being the blue tint and seconary the yellow one:
```
palette: {
    primary: {
      main: "#00235B", // Blue
      contrastText: "#F5F5F5",
    },
    secondary: {
      main: "#DADBBD", // Yellow
      contrastText: "#00235B",
    }
```
![image](https://github.com/user-attachments/assets/56ab4d83-420d-440a-893a-b83d5fafe1dc)
