### PR TITLE
S5 us101 users pagination

### DIFF
--- a/api_data/src/user/user.resolver.ts
+++ b/api_data/src/user/user.resolver.ts
@@ -1,4 +1,12 @@
-import { Resolver, Query, Mutation, Arg, InputType, Field } from "type-graphql";
+import {
+  Resolver,
+  Query,
+  Mutation,
+  Arg,
+  InputType,
+  Field,
+  Int,
+} from "type-graphql";
 import {
   validate,
   IsString,
@@ -9,6 +17,7 @@ import {
 import argon2 from "argon2";
 import { User } from "./user.entity";
 import { Role } from "../role/role.entity";
+import { PaginatedUsers } from "./user.type";
 
 @InputType()
 class RolesInput {
@@ -51,11 +60,18 @@ class CreateUserInput {
 
 @Resolver(User)
 export default class UserResolver {
-  @Query(() => [User])
-  async getUsers() {
-    return await User.find({
+  @Query(() => PaginatedUsers)
+  async getUsers(
+    @Arg("offset", () => Int, { defaultValue: 0 }) offset: number,
+    @Arg("limit", () => Int, { defaultValue: 10 }) limit: number
+  ): Promise<PaginatedUsers> {
+    const [users, totalCount] = await User.findAndCount({
       relations: ["roles"],
+      skip: offset,
+      take: limit,
     });
+
+    return { users, totalCount };
   }
 
   @Mutation(() => User)

--- a/api_data/src/user/user.type.ts
+++ b/api_data/src/user/user.type.ts
@@ -1,0 +1,11 @@
+import { ObjectType, Field, Int } from "type-graphql";
+import { User } from "./user.entity";
+
+@ObjectType()
+export class PaginatedUsers {
+  @Field(() => [User])
+  users: User[];
+
+  @Field(() => Int)
+  totalCount: number;
+}

--- a/client/src/pages/administrator/user/CreateUser.tsx
+++ b/client/src/pages/administrator/user/CreateUser.tsx
@@ -6,6 +6,7 @@ import {
 import { BooleanMap } from "../../../types/types";
 import { RefMap } from "../../../types/types";
 import useNotification from "../../../hooks/useNotification";
+import BtnLink from "../../../components/BtnLink";
 import {
   Box,
   Button,
@@ -174,7 +175,33 @@ export default function CreateUser() {
 
   return (
     <div>
-      <h1>Ajouter un utilisateur</h1>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+        }}
+      >
+        <h1>Ajouter un utilisateur</h1>
+        <BtnLink
+          to="/administrator/user"
+          sx={{
+            marginLeft: "auto",
+            backgroundColor: "secondary.main",
+            padding: "6px 8px",
+            color: "secondary.contrastText",
+            textTransform: "uppercase",
+            borderRadius: "4px",
+            textAlign: "center",
+            fontSize: ".9em",
+            "&:hover": {
+              backgroundColor: "primary.dark",
+            },
+          }}
+        >
+          Liste des utilisateurs
+        </BtnLink>
+      </Box>
+
       <Box
         component="form"
         onSubmit={handleSubmit}
@@ -313,7 +340,7 @@ export default function CreateUser() {
           </Grid>
 
           <Grid size={4}></Grid>
-          <Grid size={4}>
+          <Grid size={4} sx={{ textAlign: "center" }}>
             <Button
               disabled={handleDisabledButton()}
               type="submit"

--- a/client/src/pages/administrator/user/ManageUser.tsx
+++ b/client/src/pages/administrator/user/ManageUser.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useGetUsersQuery } from "../../../types/graphql-types";
 import BtnCrud from "../../../components/BtnCrud";
 import BtnLink from "../../../components/BtnLink";
@@ -10,8 +11,7 @@ import TableRow from "@mui/material/TableRow";
 import Paper from "@mui/material/Paper";
 import Stack from "@mui/material/Stack";
 import Pagination from "@mui/material/Pagination";
-import { Box } from "@mui/material";
-import { useState } from "react";
+import Box from "@mui/material/Box";
 
 export default function ManageUser() {
   const [page, setPage] = useState<number>(1);
@@ -25,14 +25,18 @@ export default function ManageUser() {
     },
   });
 
-  const handlePageChange = (event, value) => {
+  // the event parameter is prefixed with _ to avoid the linter flag as event is not used here but is mandatory in the MUI Pagination component
+  const handlePageChange = (
+    _event: React.ChangeEvent<unknown>,
+    value: number,
+  ) => {
     setPage(value);
   };
 
   if (loading) return <p>🥁 Chargement...</p>;
   if (error) return <p>☠️ Erreur: {error.message}</p>;
 
-  const totalPages = Math.ceil(data.getUsers.totalCount / limit);
+  const totalPages = Math.ceil((data?.getUsers?.totalCount || 0) / limit);
 
   return (
     <div>
@@ -49,11 +53,12 @@ export default function ManageUser() {
           sx={{
             marginLeft: "auto",
             backgroundColor: "primary.main",
-            padding: "8px 16px",
+            padding: "6px 8px",
             color: "primary.contrastText",
             textTransform: "uppercase",
             borderRadius: "4px",
             textAlign: "center",
+            fontSize: ".9em",
             "&:hover": {
               backgroundColor: "primary.dark",
             },
@@ -105,7 +110,10 @@ export default function ManageUser() {
               ))}
           </TableBody>
         </Table>
-        <Stack spacing={2}>
+        <Stack
+          spacing={2}
+          sx={{ marginBottom: "1em", display: "flex", alignItems: "flex-end" }}
+        >
           <Pagination
             count={totalPages}
             page={page}

--- a/client/src/pages/administrator/user/ManageUser.tsx
+++ b/client/src/pages/administrator/user/ManageUser.tsx
@@ -9,13 +9,30 @@ import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import Paper from "@mui/material/Paper";
 import Stack from "@mui/material/Stack";
+import Pagination from "@mui/material/Pagination";
 import { Box } from "@mui/material";
+import { useState } from "react";
 
 export default function ManageUser() {
-  const { loading, error, data } = useGetUsersQuery();
+  const [page, setPage] = useState<number>(1);
+  const [limit] = useState<number>(2);
+  const offset = (page - 1) * limit;
+
+  const { loading, error, data } = useGetUsersQuery({
+    variables: {
+      limit: limit,
+      offset: offset,
+    },
+  });
+
+  const handlePageChange = (event, value) => {
+    setPage(value);
+  };
 
   if (loading) return <p>🥁 Chargement...</p>;
   if (error) return <p>☠️ Erreur: {error.message}</p>;
+
+  const totalPages = Math.ceil(data.getUsers.totalCount / limit);
 
   return (
     <div>
@@ -36,11 +53,9 @@ export default function ManageUser() {
             color: "primary.contrastText",
             textTransform: "uppercase",
             borderRadius: "4px",
-            textDecoration: "none",
             textAlign: "center",
             "&:hover": {
               backgroundColor: "primary.dark",
-              textDecoration: "none",
             },
           }}
         >
@@ -61,7 +76,7 @@ export default function ManageUser() {
           </TableHead>
           <TableBody>
             {data &&
-              data.getUsers.map((user) => (
+              data.getUsers.users.map((user) => (
                 <TableRow
                   key={user.id}
                   sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
@@ -90,6 +105,15 @@ export default function ManageUser() {
               ))}
           </TableBody>
         </Table>
+        <Stack spacing={2}>
+          <Pagination
+            count={totalPages}
+            page={page}
+            onChange={handlePageChange}
+            showFirstButton
+            showLastButton
+          />
+        </Stack>
       </TableContainer>
     </div>
   );

--- a/client/src/schema/queries.ts
+++ b/client/src/schema/queries.ts
@@ -1,16 +1,20 @@
 import { gql } from "@apollo/client";
 
 export const GET_USERS = gql`
-  query GetUsers {
-    getUsers {
-      id
-      firstname
-      lastname
-      email
-      roles {
+  query GetUsers($limit: Int!, $offset: Int!) {
+    getUsers(limit: $limit, offset: $offset) {
+      users {
         id
-        label
+        firstname
+        lastname
+        email
+        password
+        roles {
+          id
+          label
+        }
       }
+      totalCount
     }
   }
 `;


### PR DESCRIPTION
![Screenshot From 2024-12-11 14-18-33](https://github.com/user-attachments/assets/c9ac6598-3326-470f-acd6-da89cab479ef)

- added pagination for users list
- modified users query in GraphQL to return the totalCount of records at the same time as the records:
```
query GetUsers($limit: Int!, $offset: Int!) {
    getUsers(limit: $limit, offset: $offset) {
      users {
        id
        firstname
        lastname
        email
        password
        roles {
          id
          label
        }
      }
      totalCount
    }
  }
```