### PR TITLE
FIX Apollo Client missing credentials

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,8 +1,5 @@
-// import { useEffect } from "react";
 import { Outlet, useLocation } from "react-router";
 import NotificationProvider from "./context/NotificationContext";
-// import { useUser } from "./hooks/useUser";
-// import { useGetAuthenticatedUserQuery } from "./types/graphql-types";
 import Header from "./components/header/Header";
 import Footer from "./components/footer/Footer";
 import Drawer from "./components/drawer/Drawer";
@@ -61,32 +58,6 @@ const theme = createTheme({
 function App() {
   const location = useLocation();
   const currentPage = location.pathname;
-
-  // const {
-  //   data: loggedInUser,
-  //   loading,
-  //   error: loggedInUserError,
-  // } = useGetAuthenticatedUserQuery();
-
-  // const { setUser } = useUser();
-
-  // useEffect(() => {
-  //   if (!loggedInUserError && loggedInUser) {
-  //     setUser({
-  //       id: loggedInUser!.getAuthenticatedUser.id,
-  //       firstname: loggedInUser!.getAuthenticatedUser.firstname,
-  //       lastname: loggedInUser!.getAuthenticatedUser.lastname,
-  //       email: loggedInUser!.getAuthenticatedUser.email,
-  //       roles: loggedInUser!.getAuthenticatedUser.roles.map((role) =>
-  //         role.id.toString(),
-  //       ),
-  //     });
-  //   }
-  // }, [loggedInUser, loggedInUserError, setUser]);
-
-  // if (loading) {
-  //   return <Box>🥁 Chargement...</Box>;
-  // }
 
   return (
     <>

--- a/client/src/context/AuthContext.tsx
+++ b/client/src/context/AuthContext.tsx
@@ -40,7 +40,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   useEffect(() => {
     // Check authentication status on mount
     checkAuth();
-  }, []);
+  }, [window.location.pathname]);
 
   const {
     //data: loggedInUser,
@@ -49,6 +49,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   } = useGetAuthenticatedUserQuery({
     fetchPolicy: "network-only", // Don't use cache
     errorPolicy: "all", // Handle errors without throwing
+    // This ensures the query runs on component mount
+    skip: false,
+    // Add credentials to all requests
+    context: {
+      credentials: "include",
+    },
   });
 
   const checkAuth = async () => {

--- a/client/src/services/connection.ts
+++ b/client/src/services/connection.ts
@@ -3,6 +3,12 @@ import { ApolloClient, InMemoryCache } from "@apollo/client";
 const connexion = new ApolloClient({
   uri: import.meta.env.VITE_API_URL,
   cache: new InMemoryCache(),
+  defaultOptions: {
+    watchQuery: {
+      fetchPolicy: "network-only",
+    },
+  },
+  credentials: "include", // This is crucial for cookie-based auth
 });
 
 export default connexion;


### PR DESCRIPTION
- Added `credentials: "include"` in Apollo Client, crucial for cookie-based auth
- In AuthContext, in the useEffect, added `window.location.pathname` in the dependencies to ensure auth is checked when typing a direct URL:
```
  useEffect(() => {
    // Check authentication status on mount
    checkAuth();
  }, [window.location.pathname]);
```