### PR TITLE
S7 US16 import the big dataset

### DIFF
--- a/api_data/Dockerfile
+++ b/api_data/Dockerfile
@@ -8,4 +8,5 @@ COPY ./jest.config.ts .
 COPY tests tests
 EXPOSE 4000
 
-CMD ["npm", "run", "devseed"]
+# CMD ["npm", "run", "devseed"]
+CMD ["npm", "run", "initdataset"]

--- a/api_data/db_import/import.sql
+++ b/api_data/db_import/import.sql
@@ -1,0 +1,25 @@
+CREATE TABLE csv_import (
+  category VARCHAR(50),
+  subcategory VARCHAR(50),
+  code_subcategory VARCHAR(30),
+  credit_debit VARCHAR(20),
+  amount_without_vat FLOAT(4),
+  vat FLOAT(4),
+  label VARCHAR(50),
+  date VARCHAR(20),
+  bank VARCHAR(50),
+  bank_act VARCHAR(100),
+  num_act VARCHAR(100),
+  receipt VARCHAR(100),
+  commission VARCHAR(100),
+  representant VARCHAR(100),
+  representant_email VARCHAR(100),
+  info VARCHAR(255)
+);
+
+-- categorie,subcategory,code_subcategory,credit_debit,amount_without_vat,vat,label,date,bank,bank_act,num_act,receipt,commission,representant,representant_email,info
+
+COPY csv_import
+FROM '/docker-entrypoint-initdb.d/dataset.csv'
+DELIMITER ','
+CSV HEADER;

--- a/api_data/package.json
+++ b/api_data/package.json
@@ -10,7 +10,7 @@
     "dev": "ts-node-dev ./src/index.ts",
     "seed": "ts-node-dev ./src/db/seed.ts",
     "devseed": "ts-node-dev ./src/db/seed.ts && ts-node-dev ./src/index.ts",
-    "initdataset": "ts-node-dev ./src/db/seed_dataset.ts && ./src/index.ts"
+    "initdataset": "ts-node-dev ./src/db/seed_dataset.ts && ts-node-dev ./src/index.ts"
   },
   "keywords": [],
   "author": "",

--- a/api_data/package.json
+++ b/api_data/package.json
@@ -9,7 +9,8 @@
     "compile": "tsc",
     "dev": "ts-node-dev ./src/index.ts",
     "seed": "ts-node-dev ./src/db/seed.ts",
-    "devseed": "ts-node-dev ./src/db/seed.ts && ts-node-dev ./src/index.ts"
+    "devseed": "ts-node-dev ./src/db/seed.ts && ts-node-dev ./src/index.ts",
+    "initdataset": "ts-node-dev ./src/db/seed_dataset.ts && ./src/index.ts"
   },
   "keywords": [],
   "author": "",

--- a/api_data/src/db/seed_dataset.ts
+++ b/api_data/src/db/seed_dataset.ts
@@ -1,0 +1,242 @@
+import { AppDataSource } from "./data-source";
+
+(async () => {
+  // initializing data source
+  await AppDataSource.initialize();
+
+  console.info("Starting Seeding...");
+
+  const queryRunner = AppDataSource.createQueryRunner();
+
+  try {
+    await queryRunner.startTransaction();
+
+    // big cleanup
+    await queryRunner.query(`DELETE FROM "bank_account"`);
+    await queryRunner.query(`DELETE FROM "bank"`);
+    await queryRunner.query(`DELETE FROM "subcategory"`);
+    await queryRunner.query(`DELETE FROM "category"`);
+    await queryRunner.query(`DELETE FROM "commission"`);
+    await queryRunner.query(`DELETE FROM "exercise"`);
+    await queryRunner.query(`DELETE FROM "credit_debit"`);
+    await queryRunner.query(`DELETE FROM "vat"`);
+    await queryRunner.query(`DELETE FROM "status"`);
+    await queryRunner.query(`DELETE FROM "invoice"`);
+    await queryRunner.query(`DELETE FROM "budget"`);
+    await queryRunner.query(`DELETE FROM "user_commissions_commission"`);
+    await queryRunner.query("DELETE FROM user_roles_role");
+    await queryRunner.query(`DELETE FROM "user"`);
+    await queryRunner.query(`DELETE FROM "role"`);
+
+    // init sequences
+    await queryRunner.query(`ALTER SEQUENCE role_id_seq RESTART WITH 1;`);
+    await queryRunner.query(`ALTER SEQUENCE user_id_seq RESTART WITH 1;`);
+    await queryRunner.query(`ALTER SEQUENCE bank_id_seq RESTART WITH 1;`);
+    await queryRunner.query(
+      `ALTER SEQUENCE bank_account_id_seq RESTART WITH 1;`
+    );
+    await queryRunner.query(`ALTER SEQUENCE category_id_seq RESTART WITH 1;`);
+    await queryRunner.query(
+      `ALTER SEQUENCE subcategory_id_seq RESTART WITH 1;`
+    );
+    await queryRunner.query(`ALTER SEQUENCE exercise_id_seq RESTART WITH 1;`);
+    await queryRunner.query(
+      `ALTER SEQUENCE credit_debit_id_seq RESTART WITH 1;`
+    );
+    await queryRunner.query(`ALTER SEQUENCE vat_id_seq RESTART WITH 1;`);
+    await queryRunner.query(`ALTER SEQUENCE status_id_seq RESTART WITH 1;`);
+    await queryRunner.query(`ALTER SEQUENCE commission_id_seq RESTART WITH 1;`);
+    await queryRunner.query(`ALTER SEQUENCE invoice_id_seq RESTART WITH 1;`);
+
+    // insert roles
+    await queryRunner.query(`
+      INSERT INTO "role" ("label") VALUES
+        ('Administrateur'),
+        ('Comptable'),
+        ('Responsable Commission');
+    `);
+
+    // insert status
+    await queryRunner.query(`
+      INSERT INTO "status" ("label") VALUES
+       ('Validé'),
+       ('En attente'),
+       ('Refusé');
+    `);
+
+    // insert unique credit_debit
+    await queryRunner.query(`
+      INSERT INTO credit_debit (label)
+      SELECT DISTINCT credit_debit
+      FROM csv_import
+      WHERE credit_debit IS NOT NULL
+      ON CONFLICT (label) DO NOTHING;
+    `);
+
+    // insert unique banks
+    await queryRunner.query(`
+      INSERT INTO bank (label)
+      SELECT DISTINCT bank
+      FROM csv_import
+      WHERE bank IS NOT NULL
+      ON CONFLICT (label) DO NOTHING;
+    `);
+
+    // insert unique banks accounts
+    await queryRunner.query(`
+      INSERT INTO bank_account (name, account_number, balance, "bankId")
+      SELECT DISTINCT
+          bank_act,
+          num_act,
+          0.0,
+          b.id
+      FROM csv_import ci
+      JOIN bank b ON b.label = ci.bank
+      WHERE bank_act IS NOT NULL AND num_act IS NOT NULL
+      ON CONFLICT (account_number) DO NOTHING;
+    `);
+    // insert unique categories with credit_debit relationship
+    await queryRunner.query(`
+      INSERT INTO category (label, "creditDebitId")
+      SELECT DISTINCT
+          ci.category,
+          cd.id
+      FROM csv_import ci
+      JOIN credit_debit cd ON cd.label = ci.credit_debit
+      WHERE ci.category IS NOT NULL
+      ON CONFLICT (label) DO NOTHING;
+    `);
+
+    // insert unique subcategories
+    await queryRunner.query(`
+      INSERT INTO subcategory (code, label, "categoryId")
+      SELECT DISTINCT
+          ci.code_subcategory,
+          ci.subcategory,
+          c.id
+      FROM csv_import ci
+      JOIN category c ON c.label = ci.category
+      WHERE ci.subcategory IS NOT NULL AND ci.code_subcategory IS NOT NULL;
+    `);
+
+    // insert unique commissions
+    await queryRunner.query(`
+      INSERT INTO commission (name)
+      SELECT DISTINCT commission
+      FROM csv_import
+      WHERE commission IS NOT NULL
+      ON CONFLICT (name) DO NOTHING;
+    `);
+
+    // insert unique vat
+    await queryRunner.query(`
+      INSERT INTO vat (label, rate)
+      SELECT DISTINCT
+          CASE
+              WHEN vat = 0 THEN 'No VAT'
+              ELSE CONCAT(CAST(vat * 100 AS VARCHAR), '%')
+          END,
+          vat
+      FROM csv_import
+      WHERE vat IS NOT NULL
+      ON CONFLICT (label) DO NOTHING;
+    `);
+
+    // insert unique users
+    await queryRunner.query(`
+      INSERT INTO "user" (email, firstname, lastname, password)
+      SELECT DISTINCT
+          representant_email,
+          split_part(representant, ' ', 1),
+          split_part(representant, ' ', 2),
+          '$argon2id$v=19$m=65536,t=3,p=4$kjem4qjZeE8bL8x+Nwt6hg$UtS5vzoj5WOkINl0oyNWNVZtjtH8fWe76Wzy6OQsev8'
+      FROM csv_import
+      WHERE representant_email IS NOT NULL
+      ON CONFLICT (email) DO NOTHING;
+    `);
+
+    // insert super admin (test password: whS0@cqnuros)
+    await queryRunner.query(`
+      INSERT INTO "user" ("email", "firstname", "lastname", "password") VALUES
+      ('super@admin.net', 'Super', 'Admin', '$argon2id$v=19$m=65536,t=3,p=4$kjem4qjZeE8bL8x+Nwt6hg$UtS5vzoj5WOkINl0oyNWNVZtjtH8fWe76Wzy6OQsev8');
+    `);
+
+    // insert user_roles_role
+    await queryRunner.query(`
+      INSERT INTO "user_roles_role" ("userId", "roleId") VALUES
+        (1,	3),
+        (2,	3),
+        (3,	3),
+        (4,	3),
+        (5, 3),
+        (6, 3),
+        (7, 3),
+        (8, 3),
+        (9, 3),
+        (10, 3),
+        (11, 3),
+        (12, 3),
+        (13, 3),
+        (14, 3),
+        (15, 3),
+        (16, 3),
+        (17, 3),
+        (18, 3),
+        (19, 3),
+        (20, 3),
+        (21, 1),
+        (21, 2),
+        (21, 3);
+    `);
+
+    // insert invoices
+    await queryRunner.query(`
+      INSERT INTO invoice (
+        price_without_vat,
+        label,
+        receipt,
+        info,
+        paid,
+        date,
+        "statusId",
+        "vatId",
+        "creditDebitId",
+        "subcategoryId",
+        "commissionId",
+        "bankAccountId",
+        "userId"
+      )
+      SELECT
+          ci.amount_without_vat,
+          ci.label,
+          ci.receipt,
+          ci.info,
+          true,
+          CAST(ci.date AS timestamp),
+          (SELECT id FROM status WHERE label = 'Validé'),
+          v.id,
+          cd.id,
+          sc.id,
+          com.id,
+          ba.id,
+          u.id
+      FROM csv_import ci
+      JOIN credit_debit cd ON cd.label = ci.credit_debit
+      JOIN subcategory sc ON sc.code = ci.code_subcategory
+      JOIN commission com ON com.name = ci.commission
+      JOIN bank_account ba ON ba.account_number = ci.num_act
+      JOIN "user" u ON u.email = ci.representant_email
+      JOIN vat v ON v.rate = ci.vat;
+    `);
+
+    await queryRunner.commitTransaction();
+
+    console.info("Finished Seeding.");
+  } catch (error) {
+    console.error(error);
+    await queryRunner.rollbackTransaction();
+  } finally {
+    console.info("Seeding Done.");
+    await AppDataSource.destroy();
+  }
+})();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     image: postgres
     env_file: ./.env
     restart: always
+    volumes:
+      - ./api_data/db_import:/docker-entrypoint-initdb.d/
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -d ${POSTGRES_DB} -U ${POSTGRES_USER}"]
       interval: 5s
@@ -21,7 +23,8 @@ services:
 
   api_data:
     build: ./api_data
-    command: npm run devseed
+    # command: npm run devseed
+    command: npm run initdataset
     restart: always
     env_file: .env
     volumes:
@@ -38,21 +41,21 @@ services:
   #   volumes:
   #     - ./api_email:/app/
 
-  api_upload:
-    build: ./api_upload
-    restart: always
-    volumes:
-      - ./api_upload/app:/var/www/html/app
-      - ./api_upload/src:/var/www/html/src
-      - ./api_upload/public:/var/www/html/public
-      - ./api_upload/config:/var/www/html/config
-      - ./api_upload/templates:/var/www/html/templates
-      - ./api_upload/upload:/var/www/html/upload
-    ports:
-      - 8081:8100 # to be removed when going in prod
-    depends_on:
-      db:
-        condition: service_healthy
+  # api_upload:
+  #   build: ./api_upload
+  #   restart: always
+  #   volumes:
+  #     - ./api_upload/app:/var/www/html/app
+  #     - ./api_upload/src:/var/www/html/src
+  #     - ./api_upload/public:/var/www/html/public
+  #     - ./api_upload/config:/var/www/html/config
+  #     - ./api_upload/templates:/var/www/html/templates
+  #     - ./api_upload/upload:/var/www/html/upload
+  #   ports:
+  #     - 8081:8100 # to be removed when going in prod
+  #   depends_on:
+  #     db:
+  #       condition: service_healthy
 
   client:
     build: ./client
@@ -75,4 +78,4 @@ services:
       - client
       - api_data
       # - api_email
-      - api_upload
+      # - api_upload

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,21 +41,21 @@ services:
   #   volumes:
   #     - ./api_email:/app/
 
-  # api_upload:
-  #   build: ./api_upload
-  #   restart: always
-  #   volumes:
-  #     - ./api_upload/app:/var/www/html/app
-  #     - ./api_upload/src:/var/www/html/src
-  #     - ./api_upload/public:/var/www/html/public
-  #     - ./api_upload/config:/var/www/html/config
-  #     - ./api_upload/templates:/var/www/html/templates
-  #     - ./api_upload/upload:/var/www/html/upload
-  #   ports:
-  #     - 8081:8100 # to be removed when going in prod
-  #   depends_on:
-  #     db:
-  #       condition: service_healthy
+  api_upload:
+    build: ./api_upload
+    restart: always
+    volumes:
+      - ./api_upload/app:/var/www/html/app
+      - ./api_upload/src:/var/www/html/src
+      - ./api_upload/public:/var/www/html/public
+      - ./api_upload/config:/var/www/html/config
+      - ./api_upload/templates:/var/www/html/templates
+      - ./api_upload/upload:/var/www/html/upload
+    ports:
+      - 8081:8100
+    depends_on:
+      db:
+        condition: service_healthy
 
   client:
     build: ./client
@@ -78,4 +78,4 @@ services:
       - client
       - api_data
       # - api_email
-      # - api_upload
+      - api_upload

--- a/nginx.conf
+++ b/nginx.conf
@@ -23,9 +23,9 @@ http {
 		# 	proxy_pass http://api_email:3000;
 		# }
 
-		# location /upload {
-		# 	proxy_pass http://api_upload:8100;
-		# }
+		location /upload {
+			proxy_pass http://api_upload:8100;
+		}
 
 		location / {
 			proxy_pass http://client:5173;

--- a/nginx.conf
+++ b/nginx.conf
@@ -23,9 +23,9 @@ http {
 		# 	proxy_pass http://api_email:3000;
 		# }
 
-		location /upload {
-			proxy_pass http://api_upload:8100;
-		}
+		# location /upload {
+		# 	proxy_pass http://api_upload:8100;
+		# }
 
 		location / {
 			proxy_pass http://client:5173;


### PR DESCRIPTION
The 10000 rows dataset is now being imported (using SQL queries) into our schema.

## Import the CSV file
A new folder `db_import` has been added at the root of `api_data`. It containes 2 files:
- a SQL file
- the dataset (CSV format)
Its purpose is to automatically import the CSV file into a `csv_import` table in Postgres when the container starts.
The Postgres container can do this by placing any SQL file in the `/docker-entrypoint-initdb.d/` folder. This is the job of the `import.sql` file.

## New seeder
A new seeder dedicated for the dataset has been added in the `db` folder, it's called `seed_dataset.ts`. The first part is identical to the seed.ts (cleaning up the tables and resetting the sequential IDs), the second part is where the _magic_ happens. Basically it is using the DISTINCT clause to select only once any records before insertion, and it is using the ON CONFLICT Postgres clause to do nothing when an error/conflict happens. 
Example:
```
INSERT INTO bank (label)
SELECT DISTINCT bank
FROM csv_import
WHERE bank IS NOT NULL
ON CONFLICT (label) DO NOTHING;
```

Here, the query will insert a `label` into the `bank` table. The values inserted are coming from a SELECT DISTINCT on the csv_import table to ensure nothing is inserted if it already exists. The ON CONFLICT (label) DO NOTHING simply tells Postgres to ignore any conflicting attempt to insert an already existing value.

## npm script
A new npm script has been added:
`"initdataset": "ts-node-dev ./src/db/seed_dataset.ts && ts-node-dev ./src/index.ts"`
It's using the new seeder. The (api_data) Dockerfile and docker compose files are using this script now to seed the big dataset.

On my laptop, the starting process doesn't change much compared to the small seeder we had before. Not much of an impact to import 10000 rows.