### PR TITLE
refactor/client: manage exercises page with collapsible table

### DIFF
--- a/client/src/components/exercise/ExerciseRow.tsx
+++ b/client/src/components/exercise/ExerciseRow.tsx
@@ -1,0 +1,95 @@
+import { useState } from "react";
+// import { Exercise } from "../../types/graphql-types";
+import { formatDate } from "../../utils/dateUtils";
+import Table from "@mui/material/Table";
+import TableHead from "@mui/material/TableHead";
+import TableBody from "@mui/material/TableBody";
+import TableRow from "@mui/material/TableRow";
+import TableCell from "@mui/material/TableCell";
+import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
+import Collapse from "@mui/material/Collapse";
+import Typography from "@mui/material/Typography";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
+
+type Budget = {
+  amount: number;
+  commissionId: number;
+  commissions: {
+    id: number;
+    name: string;
+  };
+};
+
+type Exercise = {
+  budgets: Array<Budget>;
+  end_date: string;
+  id: number;
+  label: string;
+  start_date: string;
+};
+
+function ExerciseRow({ exercise }: { exercise: Exercise }) {
+  const [open, setOpen] = useState<boolean>(false);
+
+  return (
+    <>
+      <TableRow
+        hover
+        key={exercise.id}
+        sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
+      >
+        <TableCell>
+          <IconButton
+            aria-label="expand row"
+            size="small"
+            onClick={() => setOpen(!open)}
+          >
+            {open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+          </IconButton>
+        </TableCell>
+        <TableCell align="left" sx={{ fontWeight: "bold" }}>
+          {exercise.label}
+        </TableCell>
+        <TableCell align="left">{formatDate(exercise.start_date)}</TableCell>
+        <TableCell align="left">{formatDate(exercise.end_date)}</TableCell>
+      </TableRow>
+      <TableRow>
+        <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={6}>
+          <Collapse in={open} timeout="auto" unmountOnExit>
+            <Box sx={{ margin: 1 }}>
+              <Typography variant="h6" gutterBottom component="div">
+                Répartiton du budget
+              </Typography>
+              <Table size="small" aria-label="purchases">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Commission</TableCell>
+                    <TableCell align="right">Montant</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {exercise.budgets.map((budget) => (
+                    <TableRow hover key={budget.commissionId}>
+                      <TableCell
+                        component="th"
+                        scope="row"
+                        sx={{ fontWeight: "bold" }}
+                      >
+                        {budget.commissions.name}
+                      </TableCell>
+                      <TableCell align="right">{budget.amount} €</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </Box>
+          </Collapse>
+        </TableCell>
+      </TableRow>
+    </>
+  );
+}
+
+export default ExerciseRow;

--- a/client/src/pages/administrator/exercise/ManageExercise.tsx
+++ b/client/src/pages/administrator/exercise/ManageExercise.tsx
@@ -1,15 +1,14 @@
 import { useGetExercisesQuery } from "../../../types/graphql-types";
-import { formatDate } from "../../../utils/dateUtils";
+import ExerciseRow from "../../../components/exercise/ExerciseRow";
 import BtnLink from "../../../components/BtnLink";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
+import TableRow from "@mui/material/TableRow";
 import TableCell from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
-import TableRow from "@mui/material/TableRow";
 import Paper from "@mui/material/Paper";
 import Box from "@mui/material/Box";
-import { Stack } from "@mui/system";
 
 export default function ManageExercise() {
   const { data, loading, error } = useGetExercisesQuery();
@@ -47,55 +46,20 @@ export default function ManageExercise() {
         </BtnLink>
       </Box>
 
-      <TableContainer component={Paper}>
+      <TableContainer component={Paper} sx={{ marginTop: "1em" }}>
         <Table sx={{ minWidth: 650 }} aria-label="Tableau des exercices">
           <TableHead>
             <TableRow>
+              <TableCell></TableCell>
               <TableCell align="left">Libellé</TableCell>
               <TableCell align="left">Début</TableCell>
               <TableCell align="left">Fin</TableCell>
-              <TableCell align="left"></TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
             {data &&
               data.getExercises.map((exercise) => (
-                <TableRow
-                  key={exercise.id}
-                  sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
-                >
-                  <TableCell align="left" sx={{ fontWeight: "bold" }}>
-                    {exercise.label}
-                  </TableCell>
-                  <TableCell align="left">
-                    {formatDate(exercise.start_date)}
-                  </TableCell>
-                  <TableCell align="left">
-                    {formatDate(exercise.end_date)}
-                  </TableCell>
-                  <TableCell align="left">
-                    <Stack spacing={2} direction="row">
-                      <BtnLink
-                        to="/administrator/exercise"
-                        sx={{
-                          marginLeft: "auto",
-                          backgroundColor: "secondary.main",
-                          padding: "6px 8px",
-                          color: "secondary.contrastText",
-                          textTransform: "uppercase",
-                          borderRadius: "4px",
-                          textAlign: "center",
-                          fontSize: ".9em",
-                          "&:hover": {
-                            backgroundColor: "primary.dark",
-                          },
-                        }}
-                      >
-                        Voir
-                      </BtnLink>
-                    </Stack>
-                  </TableCell>
-                </TableRow>
+                <ExerciseRow key={exercise.id} exercise={exercise} />
               ))}
           </TableBody>
         </Table>


### PR DESCRIPTION
The manage exercises page is now using collapsible table to display the detail of the budget split among commissions:
![image](https://github.com/user-attachments/assets/8bddf71e-7dc1-45fa-a913-ccf8b64e8f5f)
