### PR TITLE
Fix DateTimeISO typed as "any" by codegen

### DIFF
--- a/client/codegen-config.ts
+++ b/client/codegen-config.ts
@@ -13,6 +13,9 @@ const config: CodegenConfig = {
       ],
       config: {
         withHooks: true,
+        scalars: {
+          DateTimeISO: "string",
+        },
       },
     },
   },


### PR DESCRIPTION
DateTimeISO is now properly typed in codegen:
![image](https://github.com/user-attachments/assets/3e20d434-45b1-406c-bb69-4f7eff9121f6)

Added this is `codegen-config.ts`:
```
config: {
        ...
        scalars: {
          DateTimeISO: "string",
        },
      },
```

⚠️ You need to rebuild the container in order for the config to be re-read.