### PR TITLE
Refactor login page + Drawer

### DIFF
--- a/api_data/src/db/seed_dataset.ts
+++ b/api_data/src/db/seed_dataset.ts
@@ -213,6 +213,18 @@ import { AppDataSource } from "./data-source";
       ON CONFLICT ("userId", "commissionId") DO NOTHING;
     `);
 
+    // superadmin gets all the commissions
+    await queryRunner.query(`
+      INSERT INTO user_commissions_commission ("userId", "commissionId") VALUES
+        (21, 1),
+        (21, 2),
+        (21, 3),
+        (21, 4),
+        (21, 5),
+        (21, 6),
+        (21, 7);
+    `);
+
     // insert exercise (civil year)
     // await queryRunner.query(`
     //   INSERT INTO "exercise" ("label", "start_date", "end_date") VALUES

--- a/client/src/components/drawer/Drawer.tsx
+++ b/client/src/components/drawer/Drawer.tsx
@@ -1,16 +1,7 @@
 import { useUser } from "../../hooks/useUser";
-import { Link } from "react-router-dom";
 import { useGetUserByIdQuery } from "../../types/graphql-types";
-import {
-  Divider,
-  Drawer,
-  List,
-  ListItem,
-  ListItemButton,
-  ListItemIcon,
-  ListItemText,
-  Toolbar,
-} from "@mui/material";
+import DrawerMenuItem from "./DrawerMenuItem";
+import { Divider, Drawer, List, Toolbar, Typography } from "@mui/material";
 import GroupIcon from "@mui/icons-material/Group";
 import TableIcon from "@mui/icons-material/TableChart";
 import PieChartSharpIcon from "@mui/icons-material/PieChartSharp";
@@ -27,10 +18,10 @@ function CustomDrawer() {
     variables: { userId: user?.id ?? 0 },
   });
 
+  const commissions = data?.getUserById.commissions || [];
+
   if (loading) return <p>Chargement...</p>;
   if (error) return <p>Erreur : {error.message}</p>;
-
-  const commissions = data?.getUserById.commissions || [];
 
   return (
     <>
@@ -42,133 +33,104 @@ function CustomDrawer() {
             backgroundColor: "#f3f3f3",
             width: drawerWidth,
             boxSizing: "border-box",
+            borderRight: "1px solid",
+            borderColor: "divider",
           },
         }}
         variant="permanent"
         anchor="left"
       >
         <Toolbar />
-        <Divider />
-        <List>
-          <ListItem disablePadding>
-            <Link to={`/administrator`}>
-              <ListItemButton>
-                <ListItemIcon>
-                  <ChevronRightIcon />
-                </ListItemIcon>
-                <ListItemText primary="Administrateur" />
-              </ListItemButton>
-            </Link>
-          </ListItem>
-          <ListItem disablePadding>
-            <Link to={`/accountant`}>
-              <ListItemButton>
-                <ListItemIcon>
-                  <ChevronRightIcon />
-                </ListItemIcon>
-                <ListItemText primary="Comptable" />
-              </ListItemButton>
-            </Link>
-          </ListItem>
-          <ListItem disablePadding>
-            <Link to={`/commission`}>
-              <ListItemButton>
-                <ListItemIcon>
-                  <ChevronRightIcon />
-                </ListItemIcon>
-                <ListItemText primary="Commission" />
-              </ListItemButton>
-            </Link>
-          </ListItem>
+        <List component="nav" sx={{ px: 1 }}>
+          <DrawerMenuItem
+            to="/administrator"
+            icon={<ChevronRightIcon />}
+            text="Administrateur"
+          />
+          <DrawerMenuItem
+            to="/accountant"
+            icon={<ChevronRightIcon />}
+            text="Comptable"
+          />
+          <DrawerMenuItem
+            to="/commission"
+            icon={<ChevronRightIcon />}
+            text="Commission"
+          />
         </List>
         <Divider />
         {/* Menu Administrateur */}
         {user?.roles.includes("1") && (
           <>
-            <List>
-              <ListItem disablePadding>
-                <Link to={`/administrator/overview`}>
-                  <ListItemButton>
-                    <ListItemIcon>
-                      <PieChartSharpIcon />
-                    </ListItemIcon>
-                    <ListItemText primary="Vue globale du budget" />
-                  </ListItemButton>
-                </Link>
-              </ListItem>
-              <ListItem disablePadding>
-                <Link to={`/administrator/user`}>
-                  <ListItemButton>
-                    <ListItemIcon>
-                      <GroupIcon />
-                    </ListItemIcon>
-                    <ListItemText primary="Gestion des utilisateurs" />
-                  </ListItemButton>
-                </Link>
-              </ListItem>
-              <ListItem disablePadding>
-                <Link to={`/administrator/exercise`}>
-                  <ListItemButton>
-                    <ListItemIcon>
-                      <CardTravelIcon />
-                    </ListItemIcon>
-                    <ListItemText primary="Gestion des exercises" />
-                  </ListItemButton>
-                </Link>
-              </ListItem>
+            <Divider sx={{ my: 1 }} />
+            <Typography
+              variant="overline"
+              sx={{ px: 3, color: "text.secondary", fontSize: "0.75rem" }}
+            >
+              Administration
+            </Typography>
+            <List component="nav" sx={{ px: 1 }}>
+              <DrawerMenuItem
+                to="/administrator/overview"
+                icon={<PieChartSharpIcon />}
+                text="Vue globale du budget"
+              />
+              <DrawerMenuItem
+                to="/administrator/user"
+                icon={<GroupIcon />}
+                text="Gestion des utilisateurs"
+              />
+              <DrawerMenuItem
+                to="/administrator/exercise"
+                icon={<CardTravelIcon />}
+                text="Gestion des exercises"
+              />
             </List>
           </>
         )}
         {/* Menu Comptable */}
         {user?.roles.includes("2") && (
           <>
-            <Divider />
-            <List>
-              <ListItem disablePadding>
-                <ListItemButton>
-                  <ListItemIcon>
-                    <TableIcon />
-                  </ListItemIcon>
-                  <ListItemText primary="Partie Comptable" />
-                </ListItemButton>
-              </ListItem>
+            <Divider sx={{ my: 1 }} />
+            <Typography
+              variant="overline"
+              sx={{ px: 3, color: "text.secondary", fontSize: "0.75rem" }}
+            >
+              Comptabilité
+            </Typography>
+            <List component="nav" sx={{ px: 1 }}>
+              <DrawerMenuItem
+                to="/accountant/dashboard"
+                icon={<TableIcon />}
+                text="Partie Comptable"
+              />
             </List>
           </>
         )}
         {/* Menu Responsable de commission */}
         {user?.roles.includes("3") && (
           <>
-            <Divider />
-            <List>
-              {commissions.length > 0 ? (
-                commissions.map((commission: { id: number; name: string }) => (
-                  <ListItem key={commission.id} disablePadding>
-                    <Link to={`/commission/${commission.id}`}>
-                      <ListItemButton>
-                        <ListItemIcon>
-                          <TableIcon />
-                        </ListItemIcon>
-                        <ListItemText primary={commission.name} />
-                      </ListItemButton>
-                    </Link>
-                  </ListItem>
-                ))
-              ) : (
-                <ListItem disablePadding>
-                  <ListItemText primary="Aucune commission assignée" />
-                </ListItem>
-              )}
-              {/* Bouton Facture pour les membres des commissions */}
-              <ListItem disablePadding>
-                <Link to={`/commission/invoice`}>
-                  <ListItemButton>
-                    <ListItemIcon>
-                      <InboxIcon />
-                    </ListItemIcon>
-                    <ListItemText primary="Nouvelle Facture" />
-                  </ListItemButton>
-                </Link>
-              </ListItem>
+            <Divider sx={{ my: 1 }} />
+            <Typography
+              variant="overline"
+              sx={{ px: 3, color: "text.secondary", fontSize: "0.75rem" }}
+            >
+              Commissions
+            </Typography>
+            <List component="nav" sx={{ px: 1 }}>
+              {commissions.map((commission) => (
+                <DrawerMenuItem
+                  key={commission.id}
+                  to={`/commission/${commission.id}`}
+                  icon={<TableIcon />}
+                  text={commission.name}
+                />
+              ))}
+              <DrawerMenuItem
+                to="/commission/invoice"
+                icon={<InboxIcon />}
+                text="Nouvelle Facture"
+              />
             </List>
           </>
         )}

--- a/client/src/components/drawer/Drawer.tsx
+++ b/client/src/components/drawer/Drawer.tsx
@@ -58,7 +58,6 @@ function CustomDrawer() {
             text="Commission"
           />
         </List>
-        <Divider />
         {/* Menu Administrateur */}
         {user?.roles.includes("1") && (
           <>

--- a/client/src/components/drawer/DrawerMenuItem.tsx
+++ b/client/src/components/drawer/DrawerMenuItem.tsx
@@ -1,0 +1,57 @@
+import { useNavigate, useLocation } from "react-router-dom";
+import {
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+} from "@mui/material";
+
+type MenuItemType = {
+  to: string;
+  icon: React.ReactNode;
+  text: string;
+};
+
+function DrawerMenuItem({ to, icon, text }: MenuItemType) {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  return (
+    <>
+      <ListItem disablePadding>
+        <ListItemButton
+          selected={location.pathname === to}
+          onClick={() => navigate(to)}
+          sx={{
+            "&.Mui-selected": {
+              backgroundColor: "primary.main",
+              color: "primary.contrastText",
+              "&:hover": {
+                backgroundColor: "primary.dark",
+              },
+              "& .MuiListItemIcon-root": {
+                color: "primary.contrastText",
+              },
+            },
+            "&:hover": {
+              backgroundColor: "action.hover",
+            },
+          }}
+        >
+          <ListItemIcon sx={{ minWidth: 40, color: "inherit" }}>
+            {icon}
+          </ListItemIcon>
+          <ListItemText
+            primary={text}
+            primaryTypographyProps={{
+              fontSize: "0.875rem",
+              fontWeight: location.pathname === to ? 500 : 400,
+            }}
+          />
+        </ListItemButton>
+      </ListItem>
+    </>
+  );
+}
+
+export default DrawerMenuItem;

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -7,7 +7,6 @@ import Stack from "@mui/material/Stack";
 import {
   Button,
   FormControl,
-  Grid2,
   IconButton,
   InputAdornment,
   InputLabel,
@@ -155,15 +154,8 @@ export default function Login() {
         </form>
 
         <Stack spacing={2} sx={{ marginTop: "4em", marginBottom: "2em" }}>
-          <Grid2 container spacing={12}>
-            Comptes de démonstration : <br />
-            SUPERADMIN: super@admin.net (mdp : whS0@cqnuros ) <br />
-            Administrateur : zen@noisette.net (mdp : whS0@cqnuros )
-            <br />
-            Comptable : wanda.hayes@example.com (mdp : whS0@cqnuros )
-            <br />
-            Commission : vincent.harris@example.com (mdp : whS0@cqnuros )
-          </Grid2>
+          Compte de démonstration SUPERADMIN: super@admin.net (mdp :
+          whS0@cqnuros )
         </Stack>
       </Box>
     </>


### PR DESCRIPTION
I refactored the Drawer for a better UI. Before it didn't follow the MUI style. Now it looks much better! In particular it highlights the current selected menu item:
![image](https://github.com/user-attachments/assets/0146f230-d1a0-4c7c-b166-4fc7c97a4588)

![image](https://github.com/user-attachments/assets/4662320e-27b4-421f-a0f5-9deb569d0acd)

- On the login page, the extra demo users list have been removed (keeping only the superadmin)
- In the seeder, the superadmin is now part of all commissions