### PR TITLE
fix/client: budget amount is now rounded in the exercises page

### DIFF
--- a/client/src/components/exercise/ExerciseRow.tsx
+++ b/client/src/components/exercise/ExerciseRow.tsx
@@ -79,7 +79,9 @@ function ExerciseRow({ exercise }: { exercise: Exercise }) {
                       >
                         {budget.commissions.name}
                       </TableCell>
-                      <TableCell align="right">{budget.amount} €</TableCell>
+                      <TableCell align="right">
+                        {budget.amount.toFixed(2)} €
+                      </TableCell>
                     </TableRow>
                   ))}
                 </TableBody>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/40162a71-e597-4f8e-a9f4-ebfb34abce21)
