### PR TITLE
refactor/client: new PageTitle component

### DIFF
--- a/client/src/components/PageTitle.tsx
+++ b/client/src/components/PageTitle.tsx
@@ -1,0 +1,41 @@
+import { ReactNode } from "react";
+import { useTheme, useMediaQuery, Typography } from "@mui/material";
+import { Box } from "@mui/system";
+
+function PageTitle({
+  title,
+  children,
+}: {
+  title: string;
+  children?: ReactNode;
+}) {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+
+  return (
+    <>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+        }}
+      >
+        <Typography
+          variant="h4"
+          gutterBottom
+          sx={{
+            fontSize: isMobile ? "18px" : "24px",
+            fontWeight: "bold",
+            marginTop: "1.5em",
+            marginBottom: "1.5em",
+          }}
+        >
+          {title}
+        </Typography>
+        {children}
+      </Box>
+    </>
+  );
+}
+
+export default PageTitle;

--- a/client/src/pages/administrator/bank/BankAccount.tsx
+++ b/client/src/pages/administrator/bank/BankAccount.tsx
@@ -1,3 +1,6 @@
+import { useGetBanksQuery, Bank } from "../../../types/graphql-types";
+import BankAccountRow from "../../../components/bank/BankAccountRow";
+import PageTitle from "../../../components/PageTitle";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
 import TableRow from "@mui/material/TableRow";
@@ -5,9 +8,6 @@ import TableCell from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import Paper from "@mui/material/Paper";
-import { Box } from "@mui/material";
-import { useGetBanksQuery, Bank } from "../../../types/graphql-types";
-import BankAccountRow from "../../../components/bank/BankAccountRow";
 
 export default function BankAccount() {
   const { data, loading, error } = useGetBanksQuery();
@@ -34,15 +34,9 @@ export default function BankAccount() {
     })) ?? [];
 
   return (
-    <div>
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-        }}
-      >
-        <h1>Soldes des comptes bancaires</h1>
-      </Box>
+    <>
+      <PageTitle title="Comptes bancaires" />
+
       <TableContainer component={Paper} sx={{ marginTop: "1em" }}>
         <Table sx={{ minWidth: 650 }} aria-label="Tableau des exercices">
           <TableHead>
@@ -58,6 +52,6 @@ export default function BankAccount() {
           </TableBody>
         </Table>
       </TableContainer>
-    </div>
+    </>
   );
 }

--- a/client/src/pages/administrator/exercise/CreateExercise.tsx
+++ b/client/src/pages/administrator/exercise/CreateExercise.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { validateExerciseSchema } from "../../../utils/exerciseValidation";
 import { useCreateNewExerciseMutation } from "../../../types/graphql-types";
 import useNotification from "../../../hooks/useNotification";
+import PageTitle from "../../../components/PageTitle";
 import { DatePicker } from "@mui/x-date-pickers/DatePicker";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
@@ -97,14 +98,8 @@ export default function CreateExercise() {
   };
 
   return (
-    <div>
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-        }}
-      >
-        <h1>Ajouter un exercice</h1>
+    <>
+      <PageTitle title="Ajouter un exercice">
         <BtnLink
           to="/administrator/exercise"
           sx={{
@@ -123,7 +118,7 @@ export default function CreateExercise() {
         >
           Liste des exercices
         </BtnLink>
-      </Box>
+      </PageTitle>
 
       <Box
         component="form"
@@ -207,6 +202,6 @@ export default function CreateExercise() {
           <Grid size={4}></Grid>
         </Grid>
       </Box>
-    </div>
+    </>
   );
 }

--- a/client/src/pages/administrator/exercise/ManageExercise.tsx
+++ b/client/src/pages/administrator/exercise/ManageExercise.tsx
@@ -1,6 +1,7 @@
 import { useGetExercisesQuery } from "../../../types/graphql-types";
 import ExerciseRow from "../../../components/exercise/ExerciseRow";
 import BtnLink from "../../../components/BtnLink";
+import PageTitle from "../../../components/PageTitle";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
 import TableRow from "@mui/material/TableRow";
@@ -8,8 +9,6 @@ import TableCell from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import Paper from "@mui/material/Paper";
-import Box from "@mui/material/Box";
-import { Typography } from "@mui/material";
 
 export default function ManageExercise() {
   const { data, loading, error } = useGetExercisesQuery();
@@ -19,15 +18,7 @@ export default function ManageExercise() {
 
   return (
     <>
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-        }}
-      >
-        <Typography variant="h2" sx={{ marginBottom: "1em", fontSize: "2em" }}>
-          Gestion des exercices
-        </Typography>
+      <PageTitle title="Gestion des exercices">
         <BtnLink
           to="/administrator/exercise/add"
           sx={{
@@ -46,7 +37,7 @@ export default function ManageExercise() {
         >
           Ajouter un exercise
         </BtnLink>
-      </Box>
+      </PageTitle>
 
       <TableContainer component={Paper} sx={{ marginTop: "1em" }}>
         <Table sx={{ minWidth: 650 }} aria-label="Tableau des exercices">

--- a/client/src/pages/administrator/exercise/SetupBudgets.tsx
+++ b/client/src/pages/administrator/exercise/SetupBudgets.tsx
@@ -1,6 +1,8 @@
 import { useParams } from "react-router-dom";
 import { useGetExerciseBudgetsQuery } from "../../../types/graphql-types";
 import BtnLink from "../../../components/BtnLink";
+import PageTitle from "../../../components/PageTitle";
+import BudgetRow from "../../../components/exercise/BudgetRow";
 import {
   Table,
   TableBody,
@@ -8,11 +10,8 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  Typography,
 } from "@mui/material";
-import { Box } from "@mui/system";
 import Paper from "@mui/material/Paper";
-import BudgetRow from "../../../components/exercise/BudgetRow";
 
 function SetupBudgets() {
   const { exerciseId } = useParams();
@@ -28,15 +27,7 @@ function SetupBudgets() {
 
   return (
     <>
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-        }}
-      >
-        <Typography variant="h2" sx={{ marginBottom: "1em", fontSize: "2em" }}>
-          Mise en place des budgets {data?.getExerciseBudgets[0].exercise.label}
-        </Typography>
+      <PageTitle title="Repartition budgets : {data?.getExerciseBudgets[0].exercise.label}">
         <BtnLink
           to="/administrator/exercise"
           sx={{
@@ -55,7 +46,7 @@ function SetupBudgets() {
         >
           Retour
         </BtnLink>
-      </Box>
+      </PageTitle>
 
       <TableContainer component={Paper} sx={{ marginTop: "1em" }}>
         <Table sx={{ minWidth: 650 }} aria-label="Tableau des exercices">

--- a/client/src/pages/administrator/invoice/InvoiceOverview.tsx
+++ b/client/src/pages/administrator/invoice/InvoiceOverview.tsx
@@ -26,6 +26,7 @@ import {
   useGetInvoicesByExerciseQuery,
 } from "../../../types/graphql-types";
 import { formatDate } from "../../../utils/dateUtils";
+import PageTitle from "../../../components/PageTitle";
 
 const InvoiceOverview = () => {
   const theme = useTheme();
@@ -116,13 +117,7 @@ const InvoiceOverview = () => {
   return (
     <Box sx={{ padding: 2 }}>
       <Stack spacing={3}>
-        <Typography
-          variant="h4"
-          gutterBottom
-          sx={{ fontSize: isMobile ? "18px" : "24px", fontWeight: "bold" }}
-        >
-          Liste des Factures
-        </Typography>
+        <PageTitle title="Liste des Factures" />
 
         <FormControl sx={{ minWidth: 200 }}>
           <InputLabel id="exercise-select-label">Exercice</InputLabel>

--- a/client/src/pages/administrator/user/CreateUser.tsx
+++ b/client/src/pages/administrator/user/CreateUser.tsx
@@ -12,6 +12,7 @@ import useNotification from "../../../hooks/useNotification";
 import BtnLink from "../../../components/BtnLink";
 import GeneratePassword from "../../../components/user/GeneratePassword";
 import PasswordField from "../../../components/user/PasswordField";
+import PageTitle from "../../../components/PageTitle";
 import {
   Box,
   Button,
@@ -174,14 +175,8 @@ export default function CreateUser() {
   };
 
   return (
-    <div>
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-        }}
-      >
-        <h1>Ajouter un utilisateur</h1>
+    <>
+      <PageTitle title="Ajouter un utilisateur">
         <BtnLink
           to="/administrator/user"
           sx={{
@@ -200,7 +195,7 @@ export default function CreateUser() {
         >
           Liste des utilisateurs
         </BtnLink>
-      </Box>
+      </PageTitle>
 
       {Object.keys(errors).length > 0 && (
         <Box sx={{ color: "red", mt: 2, textAlign: "center" }}>
@@ -395,6 +390,6 @@ export default function CreateUser() {
           <Grid size={4}></Grid>
         </Grid>
       </Box>
-    </div>
+    </>
   );
 }

--- a/client/src/pages/administrator/user/ManageUser.tsx
+++ b/client/src/pages/administrator/user/ManageUser.tsx
@@ -9,6 +9,7 @@ import {
 import useNotification from "../../../hooks/useNotification";
 import BtnCrud from "../../../components/BtnCrud";
 import BtnLink from "../../../components/BtnLink";
+import PageTitle from "../../../components/PageTitle";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
@@ -18,7 +19,6 @@ import TableRow from "@mui/material/TableRow";
 import Paper from "@mui/material/Paper";
 import Stack from "@mui/material/Stack";
 import Pagination from "@mui/material/Pagination";
-import Box from "@mui/material/Box";
 
 export default function ManageUser() {
   const [page, setPage] = useState<number>(1);
@@ -106,15 +106,8 @@ export default function ManageUser() {
   const totalPages = Math.ceil((data?.getUsers?.totalCount || 0) / limit);
 
   return (
-    <div>
-      <h1>Gestion des utilisateurs</h1>
-
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-        }}
-      >
+    <>
+      <PageTitle title="Gestion des utilisateurs">
         <BtnLink
           to="/administrator/user/add"
           sx={{
@@ -133,7 +126,7 @@ export default function ManageUser() {
         >
           Ajouter un utilisateur
         </BtnLink>
-      </Box>
+      </PageTitle>
 
       <TableContainer component={Paper}>
         <Table sx={{ minWidth: 650 }} aria-label="Tableau des utilisateurs">
@@ -143,7 +136,7 @@ export default function ManageUser() {
               <TableCell align="left">Nom</TableCell>
               <TableCell align="left">Prénom</TableCell>
               <TableCell align="left">Email</TableCell>
-              <TableCell align="left"></TableCell>
+              <TableCell align="right"></TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -159,7 +152,7 @@ export default function ManageUser() {
                   <TableCell align="left">{user.firstname}</TableCell>
                   <TableCell align="left">{user.lastname}</TableCell>
                   <TableCell align="left">{user.email}</TableCell>
-                  <TableCell align="left">
+                  <TableCell align="right">
                     <Stack spacing={2} direction="row">
                       <BtnCrud
                         disabled={false}
@@ -202,6 +195,6 @@ export default function ManageUser() {
           />
         </Stack>
       </TableContainer>
-    </div>
+    </>
   );
 }

--- a/client/src/pages/administrator/user/UpdateUser.tsx
+++ b/client/src/pages/administrator/user/UpdateUser.tsx
@@ -11,6 +11,7 @@ import {
   useUpdateUserMutation,
 } from "../../../types/graphql-types";
 import useNotification from "../../../hooks/useNotification";
+import PageTitle from "../../../components/PageTitle";
 import BtnLink from "../../../components/BtnLink";
 import GeneratePassword from "../../../components/user/GeneratePassword";
 import PasswordField from "../../../components/user/PasswordField";
@@ -195,14 +196,8 @@ export default function UpdateUser() {
   if (error) return <p>☠️ Erreur: {error.message}</p>;
 
   return (
-    <div>
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-        }}
-      >
-        <h1>Editer un utilisateur</h1>
+    <>
+      <PageTitle title="Editer un utilisateur">
         <BtnLink
           to="/administrator/user"
           sx={{
@@ -221,7 +216,7 @@ export default function UpdateUser() {
         >
           Liste des utilisateurs
         </BtnLink>
-      </Box>
+      </PageTitle>
 
       {Object.keys(errors).length > 0 && (
         <Box sx={{ color: "red", mt: 2, textAlign: "center" }}>
@@ -416,6 +411,6 @@ export default function UpdateUser() {
           <Grid size={4}></Grid>
         </Grid>
       </Box>
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
New PageTitle component to get a coherent page title.
There is an optional children props for adding extra elements inside the component:

Simple title example:
`<PageTitle title="Liste des Factures" />`

Title + button example:
```
<PageTitle title="Gestion des exercices">
        <BtnLink
          to="/administrator/exercise/add"
          sx={{
            marginLeft: "auto",
            backgroundColor: "primary.main",
            padding: "6px 8px",
            color: "primary.contrastText",
            textTransform: "uppercase",
            borderRadius: "4px",
            textAlign: "center",
            fontSize: ".9em",
            "&:hover": {
              backgroundColor: "primary.dark",
            },
          }}
        >
          Ajouter un exercise
        </BtnLink>
      </PageTitle>
```