### PR TITLE
S9 US207 authorized decorator

### DIFF
--- a/api_data/src/bank/bank.resolver.ts
+++ b/api_data/src/bank/bank.resolver.ts
@@ -1,9 +1,9 @@
-import { Query, Resolver } from "type-graphql";
+import { Query, Resolver, Authorized } from "type-graphql";
 import { Bank } from "./bank.entity";
 
 @Resolver(Bank)
 export default class BankResolver {
-  // Methode GET pour toutes les banques
+  @Authorized(["1", "2", "3"])
   @Query(() => [Bank])
   async getBanks() {
     const banks = await Bank.find({ relations: ["bankAccounts"] });

--- a/api_data/src/bank/bank.resolver.ts
+++ b/api_data/src/bank/bank.resolver.ts
@@ -3,7 +3,7 @@ import { Bank } from "./bank.entity";
 
 @Resolver(Bank)
 export default class BankResolver {
-  @Authorized(["1", "2", "3"])
+  @Authorized(["1", "2"])
   @Query(() => [Bank])
   async getBanks() {
     const banks = await Bank.find({ relations: ["bankAccounts"] });

--- a/api_data/src/bankAccount/bank_account.resolver.ts
+++ b/api_data/src/bankAccount/bank_account.resolver.ts
@@ -1,8 +1,9 @@
-import { Query, Resolver } from "type-graphql";
+import { Query, Resolver, Authorized } from "type-graphql";
 import { BankAccount } from "./bank_account.entity";
 
 @Resolver(BankAccount)
 export default class BankAccountResolver {
+  @Authorized(["1", "2", "3"])
   @Query(() => [BankAccount])
   async getBankAccounts() {
     const bankAccounts = await BankAccount.find({});

--- a/api_data/src/bankAccount/bank_account.resolver.ts
+++ b/api_data/src/bankAccount/bank_account.resolver.ts
@@ -3,7 +3,7 @@ import { BankAccount } from "./bank_account.entity";
 
 @Resolver(BankAccount)
 export default class BankAccountResolver {
-  @Authorized(["1", "2", "3"])
+  @Authorized(["1", "2"])
   @Query(() => [BankAccount])
   async getBankAccounts() {
     const bankAccounts = await BankAccount.find({});

--- a/api_data/src/budget/budget.resolver.ts
+++ b/api_data/src/budget/budget.resolver.ts
@@ -1,11 +1,11 @@
-import { Resolver, Query, Mutation, Arg, Int } from "type-graphql";
-// import { validate } from "class-validator";
+import { Resolver, Query, Mutation, Arg, Int, Authorized } from "type-graphql";
 import { Budget } from "./budget.entity";
 import { Exercise } from "../exercise/exercise.entity";
 import { BudgetOverview } from "./budget.type";
 
 @Resolver(Budget)
 export class BudgetResolver {
+  @Authorized(["1", "2", "3"])
   @Query(() => Budget, { nullable: true })
   async getCurrentBudgetByCommissionID(
     @Arg("commissionId", () => Int) commissionId: number
@@ -37,6 +37,7 @@ export class BudgetResolver {
     }
   }
 
+  @Authorized(["1", "2", "3"])
   @Query(() => BudgetOverview)
   async getBudgetOverview(): Promise<BudgetOverview> {
     try {
@@ -68,6 +69,7 @@ export class BudgetResolver {
     }
   }
 
+  @Authorized(["1", "2", "3"])
   @Query(() => [Budget])
   async getExerciseBudgets(@Arg("exerciseId") exerciseId: number) {
     try {
@@ -89,6 +91,7 @@ export class BudgetResolver {
     }
   }
 
+  @Authorized(["1", "2", "3"])
   @Mutation(() => Budget)
   async setCommissionBudgetAmount(
     @Arg("exerciseId") exerciseId: number,

--- a/api_data/src/category/category.resolver.ts
+++ b/api_data/src/category/category.resolver.ts
@@ -1,10 +1,11 @@
 import { Category } from "./category.entity";
 import { CreditDebit } from "../creditDebit/creditDebit.entity";
-import { Resolver, Query, Mutation, Arg } from "type-graphql";
+import { Resolver, Query, Mutation, Arg, Authorized } from "type-graphql";
 import { validate } from "class-validator";
 
 @Resolver(Category)
 export default class CategoryResolver {
+  @Authorized(["1", "2", "3"])
   @Query(() => [Category])
   async getCategories() {
     return Category.find({
@@ -18,6 +19,7 @@ export default class CategoryResolver {
   }
 
   // add a new category
+  @Authorized(["1", "2", "3"])
   @Mutation(() => Category)
   async addCategory(
     @Arg("label") label: string,
@@ -58,6 +60,7 @@ export default class CategoryResolver {
   }
 
   // update a category
+  @Authorized([1, 2, 3])
   @Mutation(() => Category)
   async updateCategory(
     @Arg("id") id: number,

--- a/api_data/src/category/category.resolver.ts
+++ b/api_data/src/category/category.resolver.ts
@@ -19,7 +19,7 @@ export default class CategoryResolver {
   }
 
   // add a new category
-  @Authorized(["1", "2", "3"])
+  @Authorized(["2"])
   @Mutation(() => Category)
   async addCategory(
     @Arg("label") label: string,
@@ -60,7 +60,7 @@ export default class CategoryResolver {
   }
 
   // update a category
-  @Authorized([1, 2, 3])
+  @Authorized(["2"])
   @Mutation(() => Category)
   async updateCategory(
     @Arg("id") id: number,

--- a/api_data/src/commission/commission.resolver.ts
+++ b/api_data/src/commission/commission.resolver.ts
@@ -2,15 +2,18 @@ import { Between } from "typeorm";
 import { Exercise } from "../exercise/exercise.entity";
 import { Invoice } from "../invoice/invoice.entity";
 import { Commission } from "./commission.entity";
-import { Resolver, Query, Arg } from "type-graphql";
+import { Resolver, Query, Arg, Authorized } from "type-graphql";
 import { PaginatedInvoices } from "../invoice/paginatedInvoice.type";
 
 @Resolver(Commission)
 export default class CommissionResolver {
+  @Authorized(["1", "2", "3"])
   @Query(() => [Commission])
   async getCommissions() {
     return Commission.find();
   }
+
+  @Authorized(["1", "2", "3"])
   @Query(() => PaginatedInvoices)
   async getInvoicesByCommissionId(
     @Arg("commissionId") commissionId: number,

--- a/api_data/src/creditDebit/creditDebit.resolver.ts
+++ b/api_data/src/creditDebit/creditDebit.resolver.ts
@@ -1,8 +1,9 @@
-import { Resolver, Query } from "type-graphql";
+import { Resolver, Query, Authorized } from "type-graphql";
 import { CreditDebit } from "./creditDebit.entity";
 
 @Resolver(CreditDebit)
 export default class CreditDebitResolver {
+  @Authorized(["1", "2", "3"])
   @Query(() => [CreditDebit])
   async getCreditDebits(): Promise<CreditDebit[]> {
     return await CreditDebit.find();

--- a/api_data/src/exercise/exercise.resolver.ts
+++ b/api_data/src/exercise/exercise.resolver.ts
@@ -1,4 +1,4 @@
-import { Resolver, Query, Mutation, Arg } from "type-graphql";
+import { Resolver, Query, Mutation, Arg, Authorized } from "type-graphql";
 import { validate } from "class-validator";
 import { Exercise } from "./exercise.entity";
 import { Budget } from "../budget/budget.entity";
@@ -7,6 +7,7 @@ import { ExerciseInput } from "./exercise.type";
 
 @Resolver(Exercise)
 export default class ExerciseResolver {
+  @Authorized(["1", "2", "3"])
   @Query(() => [Exercise])
   async getExercises() {
     const exercises = await Exercise.find({
@@ -19,6 +20,7 @@ export default class ExerciseResolver {
     return exercises;
   }
 
+  @Authorized(["1", "2", "3"])
   @Mutation(() => Exercise)
   async createNewExercise(@Arg("data") data: ExerciseInput) {
     try {

--- a/api_data/src/invoice/invoice.resolver.ts
+++ b/api_data/src/invoice/invoice.resolver.ts
@@ -1,4 +1,4 @@
-import { Resolver, Query, Arg } from "type-graphql";
+import { Resolver, Query, Arg, Authorized } from "type-graphql";
 import { Invoice } from "./invoice.entity";
 import { Subcategory } from "../subcategory/subcategory.entity";
 import { Status } from "../status/status.entity";
@@ -14,6 +14,7 @@ import { Exercise } from "../exercise/exercise.entity";
 
 @Resolver(Invoice)
 export default class InvoiceResolver {
+  @Authorized(["1", "2", "3"])
   @Query(() => [Invoice])
   async getInvoices(): Promise<Invoice[]> {
     try {
@@ -113,6 +114,7 @@ export default class InvoiceResolver {
     }
   }
 
+  @Authorized(["1", "2", "3"])
   @Query(() => [Invoice])
   async getInvoicesToValidateOrRefused(): Promise<Invoice[]> {
     try {
@@ -195,6 +197,7 @@ export default class InvoiceResolver {
     }
   }
 
+  @Authorized(["1", "2", "3"])
   @Query(() => PaginatedInvoices)
   async getInvoicesByExercise(
     @Arg("exerciseId") exerciseId: number,

--- a/api_data/src/role/role.resolver.ts
+++ b/api_data/src/role/role.resolver.ts
@@ -1,8 +1,9 @@
-import { Resolver, Query } from "type-graphql";
+import { Resolver, Query, Authorized } from "type-graphql";
 import { Role } from "./role.entity";
 
 @Resolver(Role)
 export default class RoleResolver {
+  @Authorized(["1", "2", "3"])
   @Query(() => [Role])
   async getRoles() {
     return await Role.find();

--- a/api_data/src/schema.ts
+++ b/api_data/src/schema.ts
@@ -31,9 +31,19 @@ const getSchema = async () => {
       ExerciseResolver,
     ],
     validate: true,
-    authChecker: ({ context }): boolean => {
-      if (context.loggedInUser) return true;
-      return false;
+    authChecker: ({ context }, rolesId: number[]): boolean => {
+      /** context.loggedInUser
+       * {
+            id: user.id,
+            email: user.email,
+            firstname: user.firstname,
+            lastname: user.lastname,
+            roles: [1,2,3] // [admin: 1, compta: 2, commission: 3]
+          },
+       */
+      return context.loggedInUser.roles.some((role: number) =>
+        rolesId.includes(role)
+      );
     },
   });
 };

--- a/api_data/src/schema.ts
+++ b/api_data/src/schema.ts
@@ -31,19 +31,22 @@ const getSchema = async () => {
       ExerciseResolver,
     ],
     validate: true,
-    authChecker: ({ context }, rolesId: number[]): boolean => {
+    authChecker: ({ context }, rolesId: string[]): boolean => {
       /** context.loggedInUser
        * {
             id: user.id,
             email: user.email,
             firstname: user.firstname,
             lastname: user.lastname,
-            roles: [1,2,3] // [admin: 1, compta: 2, commission: 3]
+            roles: [ { id: 1 }, { id: 2 }, { id: 3 } ] // [admin: 1, compta: 2, commission: 3]
           },
        */
-      return context.loggedInUser.roles.some((role: number) =>
-        rolesId.includes(role)
+
+      const hasRole = context.loggedInUser.roles.some((role: { id: number }) =>
+        rolesId.includes(String(role.id))
       );
+
+      return hasRole;
     },
   });
 };

--- a/api_data/src/status/status.resolver.ts
+++ b/api_data/src/status/status.resolver.ts
@@ -1,8 +1,9 @@
-import { Resolver, Query } from "type-graphql";
+import { Resolver, Query, Authorized } from "type-graphql";
 import { Status } from "./status.entity";
 
 @Resolver(Status)
 export default class StatusResolver {
+  @Authorized(["1", "2", "3"])
   @Query(() => [Status])
   async getStatus() {
     return await Status.find();

--- a/api_data/src/subcategory/subcategory.resolver.ts
+++ b/api_data/src/subcategory/subcategory.resolver.ts
@@ -11,7 +11,7 @@ export default class SubcategoryResolver {
     return Subcategory.find();
   }
 
-  @Authorized(["1", "2", "3"])
+  @Authorized(["2"])
   @Mutation(() => Subcategory)
   async addSubcategory(
     @Arg("label") label: string,
@@ -39,7 +39,7 @@ export default class SubcategoryResolver {
     return subcategory;
   }
 
-  @Authorized(["1", "2", "3"])
+  @Authorized(["2"])
   @Mutation(() => Subcategory)
   async updateSubcategory(
     @Arg("id") id: number,

--- a/api_data/src/subcategory/subcategory.resolver.ts
+++ b/api_data/src/subcategory/subcategory.resolver.ts
@@ -1,14 +1,17 @@
+import { Resolver, Mutation, Query, Arg, Authorized } from "type-graphql";
+import { validate } from "class-validator";
 import { Subcategory } from "./subcategory.entity";
 import { Category } from "../category/category.entity";
-import { Resolver, Mutation, Query, Arg } from "type-graphql";
-import { validate } from "class-validator";
 
 @Resolver(Subcategory)
 export default class SubcategoryResolver {
+  @Authorized(["1", "2", "3"])
   @Query(() => [Subcategory])
   async getSubcategories() {
     return Subcategory.find();
   }
+
+  @Authorized(["1", "2", "3"])
   @Mutation(() => Subcategory)
   async addSubcategory(
     @Arg("label") label: string,
@@ -36,6 +39,7 @@ export default class SubcategoryResolver {
     return subcategory;
   }
 
+  @Authorized(["1", "2", "3"])
   @Mutation(() => Subcategory)
   async updateSubcategory(
     @Arg("id") id: number,

--- a/api_data/src/user/user.resolver.ts
+++ b/api_data/src/user/user.resolver.ts
@@ -67,7 +67,7 @@ export default class UserResolver {
     return { users, totalCount };
   }
 
-  @Authorized([1])
+  @Authorized([1, 2, 3])
   @Query(() => User)
   async getUserById(@Arg("userId") userId: number) {
     const user = await User.findOneOrFail({

--- a/api_data/src/user/user.resolver.ts
+++ b/api_data/src/user/user.resolver.ts
@@ -244,7 +244,7 @@ export default class UserResolver {
             );
 
             return {
-              token: token,
+              //SECU: tokenInMemory different from the cookie
               id: user.id,
               email: user.email,
               firstname: user.firstname,

--- a/api_data/src/user/user.resolver.ts
+++ b/api_data/src/user/user.resolver.ts
@@ -1,4 +1,12 @@
-import { Resolver, Query, Mutation, Arg, Int, Ctx } from "type-graphql";
+import {
+  Resolver,
+  Query,
+  Mutation,
+  Arg,
+  Int,
+  Ctx,
+  Authorized,
+} from "type-graphql";
 import { validate } from "class-validator";
 import { AppDataSource } from "../db/data-source";
 import {
@@ -39,6 +47,7 @@ interface UserContext {
 
 @Resolver(User)
 export default class UserResolver {
+  @Authorized([1])
   @Query(() => PaginatedUsers)
   async getUsers(
     @Arg("offset", () => Int, { defaultValue: 0 }) offset: number,
@@ -58,6 +67,7 @@ export default class UserResolver {
     return { users, totalCount };
   }
 
+  @Authorized([1])
   @Query(() => User)
   async getUserById(@Arg("userId") userId: number) {
     const user = await User.findOneOrFail({
@@ -72,6 +82,7 @@ export default class UserResolver {
     return user;
   }
 
+  @Authorized([1])
   @Mutation(() => User)
   async createNewUser(@Arg("data") data: UserInput) {
     try {
@@ -109,6 +120,7 @@ export default class UserResolver {
     }
   }
 
+  @Authorized([1])
   @Mutation(() => User)
   async updateUser(
     @Arg("userId") userId: number,
@@ -157,6 +169,7 @@ export default class UserResolver {
     }
   }
 
+  @Authorized([1])
   @Mutation(() => DeleteResponseStatus)
   async softDeleteUser(@Arg("data") data: UserIdInput) {
     try {
@@ -177,6 +190,7 @@ export default class UserResolver {
     }
   }
 
+  @Authorized([1])
   @Mutation(() => RestoreResponseStatus)
   async restoreUser(@Arg("data") data: UserIdInput) {
     try {
@@ -245,6 +259,7 @@ export default class UserResolver {
 
             return {
               //SECU: tokenInMemory different from the cookie
+              token: token,
               id: user.id,
               email: user.email,
               firstname: user.firstname,

--- a/api_data/src/user/user.resolver.ts
+++ b/api_data/src/user/user.resolver.ts
@@ -47,7 +47,7 @@ interface UserContext {
 
 @Resolver(User)
 export default class UserResolver {
-  @Authorized([1])
+  @Authorized(["1"])
   @Query(() => PaginatedUsers)
   async getUsers(
     @Arg("offset", () => Int, { defaultValue: 0 }) offset: number,
@@ -67,7 +67,7 @@ export default class UserResolver {
     return { users, totalCount };
   }
 
-  @Authorized([1, 2, 3])
+  @Authorized(["1", "2", "3"])
   @Query(() => User)
   async getUserById(@Arg("userId") userId: number) {
     const user = await User.findOneOrFail({
@@ -82,7 +82,7 @@ export default class UserResolver {
     return user;
   }
 
-  @Authorized([1])
+  @Authorized(["1"])
   @Mutation(() => User)
   async createNewUser(@Arg("data") data: UserInput) {
     try {
@@ -120,7 +120,7 @@ export default class UserResolver {
     }
   }
 
-  @Authorized([1])
+  @Authorized(["1"])
   @Mutation(() => User)
   async updateUser(
     @Arg("userId") userId: number,
@@ -169,7 +169,7 @@ export default class UserResolver {
     }
   }
 
-  @Authorized([1])
+  @Authorized(["1"])
   @Mutation(() => DeleteResponseStatus)
   async softDeleteUser(@Arg("data") data: UserIdInput) {
     try {
@@ -190,7 +190,7 @@ export default class UserResolver {
     }
   }
 
-  @Authorized([1])
+  @Authorized(["1"])
   @Mutation(() => RestoreResponseStatus)
   async restoreUser(@Arg("data") data: UserIdInput) {
     try {

--- a/api_data/src/vat/vat.resolver.ts
+++ b/api_data/src/vat/vat.resolver.ts
@@ -1,8 +1,9 @@
-import { Resolver, Query } from "type-graphql";
+import { Resolver, Query, Authorized } from "type-graphql";
 import { Vat } from "./vat.entity";
 
 @Resolver(Vat)
 export default class VatResolver {
+  @Authorized(["1", "2", "3"])
   @Query(() => [Vat])
   async getVats() {
     return await Vat.find({ relations: ["invoices"] });


### PR DESCRIPTION
All resolvers are now protected using the @Authorized() decorator.
Example for the getBanks query:

```
@Authorized(["1", "2", "3"])
  @Query(() => [Bank])
  async getBanks() {
    const banks = await Bank.find({ relations: ["bankAccounts"] });
    return banks;
  }
```