### PR TITLE
refactor: api_email removed from the reverse proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
   redis:
     image: redis
     container_name: redis_cache
-    ports: 
+    ports:
       - 6379:6379
 
   api_email:
@@ -46,8 +46,6 @@ services:
     env_file: .env
     volumes:
       - ./api_email:/app/
-    ports:
-      - 3100:3000 # to be removed
 
   api_upload:
     build: ./api_upload
@@ -87,8 +85,3 @@ services:
       - api_data
       - api_email
       - api_upload
-
-
-
-
-    

--- a/nginx.conf
+++ b/nginx.conf
@@ -19,10 +19,6 @@ http {
 			proxy_pass http://api_data:4000;
 		}
 
-		location /email/ {
-			proxy_pass http://api_email:3000/;
-		}
-
 		location /upload {
 			proxy_pass http://api_upload:8100;
 		}


### PR DESCRIPTION
In order to secure api_email, it is not reachable anymore from the outside. 
- removed from nginx.conf
- exposed port removed from docker compose