### PR TITLE
Refactor admin dashboard route + Login

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -77,25 +77,6 @@ function App() {
     <>
       <ThemeProvider theme={theme}>
         <NotificationProvider>
-          {/* {currentPage === "/" ? (
-            <Login />
-          ) : currentPage === "/lost-password" ? (
-            <ILostMyPassword />
-          ) : (
-            <Box sx={{ display: "flex" }}>
-              <CssBaseline />
-              <Header
-                title="ClubCompta"
-                subtitle="Budget 2024/2025"
-                logoUrl="/Logo.svg"
-              />
-              <Drawer />
-              <Box component="main" sx={{ flexGrow: 1, p: 3, mt: "4rem" }}>
-                <Outlet />
-                <Footer />
-              </Box>
-            </Box>
-          )} */}
           {(() => {
             switch (currentPage) {
               case "/":

--- a/client/src/components/drawer/Drawer.tsx
+++ b/client/src/components/drawer/Drawer.tsx
@@ -56,7 +56,7 @@ function CustomDrawer() {
           </Typography>
           <List component="nav" sx={{ px: 1 }}>
             <DrawerMenuItem
-              to="/administrator/overview"
+              to="/administrator"
               icon={<PieChartSharpIcon />}
               text="Vue globale du budget"
             />

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -51,14 +51,8 @@ const router = createBrowserRouter([
         ),
         children: [
           {
-            path: "overview",
-            element: <Outlet />,
-            children: [
-              {
-                index: true,
-                element: <BudgetOverview />,
-              },
-            ],
+            index: true,
+            element: <BudgetOverview />,
           },
           {
             path: "invoiceOverview",

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from "react-router-dom";
 import { useUser } from "../hooks/useUser";
 import useNotification from "../hooks/useNotification";
 import Box from "@mui/material/Box";
-import Stack from "@mui/material/Stack";
 import {
   Button,
   FormControl,
@@ -108,6 +107,7 @@ export default function Login() {
               fullWidth
               id="email"
               label="Adresse Email"
+              aria-label="Adresse Email"
               name="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
@@ -121,6 +121,7 @@ export default function Login() {
                 fullWidth
                 id="password"
                 label="Mot de passe"
+                aria-label="Mot de passe"
                 name="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
@@ -149,6 +150,7 @@ export default function Login() {
               type="submit"
               fullWidth
               variant="contained"
+              aria-label="Se connecter"
               sx={{ mt: 3, mb: 2 }}
             >
               Se connecter
@@ -162,11 +164,6 @@ export default function Login() {
             </BtnLink>
           </Box>
         </form>
-
-        <Stack spacing={2} sx={{ marginTop: "4em", marginBottom: "2em" }}>
-          Compte de démonstration SUPERADMIN: super@admin.net (mdp :
-          whS0@cqnuros )
-        </Stack>
       </Box>
     </>
   );


### PR DESCRIPTION
Upon connection, an administrator is redirected to the Budget overview (/administrator)

The login page is now cleared off the superadmin credentials info:
![image](https://github.com/user-attachments/assets/3ad5ee77-9fcd-410a-b9a4-d786f45c7790)
