### PR TITLE
S11 US273 see yearly bank balances

### DIFF
--- a/api_data/src/db/seed_dataset.ts
+++ b/api_data/src/db/seed_dataset.ts
@@ -312,7 +312,7 @@ import { AppDataSource } from "./data-source";
       FROM (
           SELECT
               "bankAccountId",
-              SUM(CASE WHEN "creditDebitId" = 1 THEN "amount_with_vat" ELSE -"amount_with_vat" END) AS balance
+              SUM(CASE WHEN "creditDebitId" = 1 THEN -"amount_with_vat" ELSE "amount_with_vat" END) AS balance
           FROM
               invoice
           GROUP BY

--- a/api_data/src/invoice/invoice.resolver.ts
+++ b/api_data/src/invoice/invoice.resolver.ts
@@ -1,4 +1,7 @@
 import { Resolver, Query, Arg, Authorized, Mutation } from "type-graphql";
+import { Equal } from "typeorm";
+import { Between } from "typeorm";
+import redisClient from "../../redis.config";
 import { Invoice } from "./invoice.entity";
 import { Subcategory } from "../subcategory/subcategory.entity";
 import { Status } from "../status/status.entity";
@@ -7,11 +10,9 @@ import { CreditDebit } from "../creditDebit/creditDebit.entity";
 import { Commission } from "../commission/commission.entity";
 import { BankAccount } from "../bankAccount/bank_account.entity";
 import { User } from "../user/user.entity";
-import { Equal } from "typeorm";
-import { PaginatedInvoices } from "./paginatedInvoice.type";
-import { Between } from "typeorm";
 import { Exercise } from "../exercise/exercise.entity";
-import redisClient from "../../redis.config";
+import { PaginatedInvoices } from "./paginatedInvoice.type";
+import { InvoiceYearlySummary } from "./invoice.schema";
 
 @Resolver(Invoice)
 export default class InvoiceResolver {
@@ -322,6 +323,50 @@ export default class InvoiceResolver {
     } catch (error) {
       console.error("Error associating bank account to invoice:", error);
       throw new Error("Impossible d'associer le compte bancaire à la facture.");
+    }
+  }
+
+  @Authorized(["1", "2"])
+  @Query(() => [InvoiceYearlySummary])
+  async getYearlyInvoiceSummary(): Promise<InvoiceYearlySummary[]> {
+    try {
+      // FOr documentation, this is the SQL statement:
+      // SELECT
+      //     bankAccountId,
+      //     SUM(CASE WHEN creditDebitId = 1 THEN amount_with_vat ELSE 0 END) AS total_debit,
+      //     SUM(CASE WHEN creditDebitId = 2 THEN amount_with_vat ELSE 0 END) AS total_credit,
+      //     SUM(CASE WHEN creditDebitId = 1 THEN amount_with_vat ELSE -amount_with_vat END) AS balance
+      // FROM
+      //     invoices
+      // GROUP BY
+      //     bankAccountId;
+
+      const result = await Invoice.createQueryBuilder("invoice")
+        .select("EXTRACT(YEAR FROM invoice.date)", "year")
+        .addSelect(
+          "SUM(CASE WHEN invoice.creditDebitId = 1 THEN invoice.amount_with_vat ELSE 0 END)",
+          "total_debits"
+        )
+        .addSelect(
+          "SUM(CASE WHEN invoice.creditDebitId = 2 THEN invoice.amount_with_vat ELSE 0 END)",
+          "total_credits"
+        )
+        .addSelect(
+          "SUM(CASE WHEN invoice.creditDebitId = 1 THEN invoice.amount_with_vat WHEN invoice.creditDebitId = 2 THEN -invoice.amount_with_vat END)",
+          "balance"
+        )
+        .groupBy("EXTRACT(YEAR FROM invoice.date)")
+        .orderBy("year")
+        .getRawMany();
+
+      if (!result) {
+        throw new Error("Error getting the yearly balances.");
+      }
+
+      return result;
+    } catch (error) {
+      console.error("Error getting the yearly balances. ", error);
+      throw new Error("Impossible de récupérer les balances par années.");
     }
   }
 }

--- a/api_data/src/invoice/invoice.schema.ts
+++ b/api_data/src/invoice/invoice.schema.ts
@@ -20,10 +20,10 @@ export class InvoiceInput {
   @Field()
   date: Date;
 
-  @Field({ nullable: true })
+  @Field(() => String, { nullable: true })
   receipt?: string | null;
 
-  @Field({ nullable: true })
+  @Field(() => String, { nullable: true })
   info?: string | null;
 
   @Field(() => Int)
@@ -97,4 +97,19 @@ export class Invoice {
 
   @Field(() => Int)
   amount_with_vat: number;
+}
+
+@ObjectType()
+export class InvoiceYearlySummary {
+  @Field(() => Int)
+  year: number;
+
+  @Field(() => Float)
+  total_debits: number;
+
+  @Field(() => Float)
+  total_credits: number;
+
+  @Field(() => Float)
+  balance: number;
 }

--- a/client/src/components/budgetOverview/BudgetOverview.tsx
+++ b/client/src/components/budgetOverview/BudgetOverview.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { useGetBudgetOverviewQuery } from "../../types/graphql-types";
 import { PieChart } from "@mui/x-charts/PieChart";
 import { useMediaQuery, useTheme } from "@mui/material";
-import YearlyBalance from "./YearlyBalance";
 
 const colors = [
   "#018571",
@@ -81,10 +80,6 @@ const BudgetOverview: React.FC = () => {
             left: 20,
           }}
         />
-      </article>
-      <article style={{ textAlign: "center" }}>
-        <h2>Etats des exercises annuels</h2>
-        <YearlyBalance />
       </article>
     </>
   );

--- a/client/src/components/budgetOverview/BudgetOverview.tsx
+++ b/client/src/components/budgetOverview/BudgetOverview.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useGetBudgetOverviewQuery } from "../../types/graphql-types";
 import { PieChart } from "@mui/x-charts/PieChart";
 import { useMediaQuery, useTheme } from "@mui/material";
+import YearlyBalance from "./YearlyBalance";
 
 const colors = [
   "#018571",
@@ -32,54 +33,59 @@ const BudgetOverview: React.FC = () => {
   }));
 
   return (
-    <article style={{ textAlign: "center" }}>
-      <h2>Vue d'ensemble des budgets</h2>
-      <h3>Budget global : {globalBudget.toFixed(2)} €</h3>
-      <PieChart
-        series={[
-          {
-            arcLabel: (item) => `${item.value.toFixed(2)}€`,
-            arcLabelMinAngle: 20,
-            arcLabelRadius: isMobile ? "70%" : "60%",
-            data: pieChartData,
-            innerRadius: 50,
-            outerRadius: isMobile ? 140 : 190,
-            startAngle: 0,
-            endAngle: 360,
-            cornerRadius: 0,
-            highlightScope: { fade: "global", highlight: "item" },
-            faded: {
-              innerRadius: 30,
-              additionalRadius: -30,
-              color: "gray",
+    <>
+      <article style={{ textAlign: "center" }}>
+        <h2>Vue d'ensemble des budgets</h2>
+        <h3>Budget global : {globalBudget.toFixed(2)} €</h3>
+        <PieChart
+          series={[
+            {
+              arcLabel: (item) => `${item.value.toFixed(2)}€`,
+              arcLabelMinAngle: 20,
+              arcLabelRadius: isMobile ? "70%" : "60%",
+              data: pieChartData,
+              innerRadius: 50,
+              outerRadius: isMobile ? 140 : 190,
+              startAngle: 0,
+              endAngle: 360,
+              cornerRadius: 0,
+              highlightScope: { fade: "global", highlight: "item" },
+              faded: {
+                innerRadius: 30,
+                additionalRadius: -30,
+                color: "gray",
+              },
+              valueFormatter: (value: { value: number }) =>
+                `${value.value.toFixed(2)} €`,
             },
-            valueFormatter: (value: { value: number }) =>
-              `${value.value.toFixed(2)} €`,
-          },
-        ]}
-        height={isMobile ? 400 : 500}
-        slotProps={{
-          legend: {
-            direction: isMobile ? "row" : "column",
-            position: {
-              vertical: isMobile ? "bottom" : "middle",
-              horizontal: isMobile ? "middle" : "right",
+          ]}
+          height={isMobile ? 400 : 500}
+          slotProps={{
+            legend: {
+              direction: isMobile ? "row" : "column",
+              position: {
+                vertical: isMobile ? "bottom" : "middle",
+                horizontal: isMobile ? "middle" : "right",
+              },
+              padding: isMobile ? 10 : 90,
+              itemMarkWidth: isMobile ? 10 : 20,
+              itemMarkHeight: isMobile ? 10 : 20,
+              markGap: isMobile ? 5 : 15,
+              itemGap: isMobile ? 5 : 30,
             },
-            padding: isMobile ? 10 : 90,
-            itemMarkWidth: isMobile ? 10 : 20,
-            itemMarkHeight: isMobile ? 10 : 20,
-            markGap: isMobile ? 5 : 15,
-            itemGap: isMobile ? 5 : 30,
-          },
-        }}
-        margin={{
-          top: 20,
-          right: isMobile ? 20 : 100,
-          bottom: isMobile ? 120 : 20,
-          left: 20,
-        }}
-      />
-    </article>
+          }}
+          margin={{
+            top: 20,
+            right: isMobile ? 20 : 100,
+            bottom: isMobile ? 120 : 20,
+            left: 20,
+          }}
+        />
+      </article>
+      <article style={{ textAlign: "center" }}>
+        <YearlyBalance />
+      </article>
+    </>
   );
 };
 

--- a/client/src/components/budgetOverview/BudgetOverview.tsx
+++ b/client/src/components/budgetOverview/BudgetOverview.tsx
@@ -83,6 +83,7 @@ const BudgetOverview: React.FC = () => {
         />
       </article>
       <article style={{ textAlign: "center" }}>
+        <h2>Etats des exercises annuels</h2>
         <YearlyBalance />
       </article>
     </>

--- a/client/src/components/budgetOverview/YearlyBalance.tsx
+++ b/client/src/components/budgetOverview/YearlyBalance.tsx
@@ -1,12 +1,13 @@
-import { BarChart } from "@mui/x-charts/BarChart";
-import { axisClasses } from "@mui/x-charts/ChartsAxis";
 import { useGetYearlyInvoiceSummaryQuery } from "../../types/graphql-types";
 import { currencySignValueFormatter } from "../../utils/chartsUtils";
+import { BarChart } from "@mui/x-charts/BarChart";
+import { axisClasses } from "@mui/x-charts/ChartsAxis";
+import { Box } from "@mui/system";
 
 const chartSetting = {
   width: 800,
   height: 300,
-  margin: { left: 200 },
+  // margin: { left: 10 },
   sx: {
     [`.${axisClasses.left} .${axisClasses.label}`]: {
       transform: "translate(-20px, 0)",
@@ -22,39 +23,41 @@ function YearlyBalance() {
 
   return (
     <>
-      <BarChart
-        dataset={data?.getYearlyInvoiceSummary}
-        xAxis={[{ scaleType: "band", dataKey: "year" }]}
-        yAxis={[
-          {
-            scaleType: "linear",
-            dataKey: "balance",
-            valueFormatter: (value: number) =>
-              new Intl.NumberFormat("fr-FR", {
-                style: "currency",
-                currency: "EUR",
-              }).format(value),
-          },
-        ]}
-        series={[
-          {
-            dataKey: "total_credits",
-            label: "Crédit",
-            valueFormatter: currencySignValueFormatter,
-          },
-          {
-            dataKey: "total_debits",
-            label: "Débit",
-            valueFormatter: currencySignValueFormatter,
-          },
-          {
-            dataKey: "balance",
-            label: "Balance",
-            valueFormatter: currencySignValueFormatter,
-          },
-        ]}
-        {...chartSetting}
-      />
+      <Box sx={{ display: "flex", justifyContent: "center" }}>
+        <BarChart
+          dataset={data?.getYearlyInvoiceSummary}
+          xAxis={[{ scaleType: "band", dataKey: "year" }]}
+          yAxis={[
+            {
+              scaleType: "linear",
+              dataKey: "balance",
+              valueFormatter: (value: number) =>
+                new Intl.NumberFormat("fr-FR", {
+                  style: "currency",
+                  currency: "EUR",
+                }).format(value),
+            },
+          ]}
+          series={[
+            {
+              dataKey: "total_credits",
+              label: "Crédit",
+              valueFormatter: currencySignValueFormatter,
+            },
+            {
+              dataKey: "total_debits",
+              label: "Débit",
+              valueFormatter: currencySignValueFormatter,
+            },
+            {
+              dataKey: "balance",
+              label: "Balance",
+              valueFormatter: currencySignValueFormatter,
+            },
+          ]}
+          {...chartSetting}
+        />
+      </Box>
     </>
   );
 }

--- a/client/src/components/budgetOverview/YearlyBalance.tsx
+++ b/client/src/components/budgetOverview/YearlyBalance.tsx
@@ -23,41 +23,50 @@ function YearlyBalance() {
 
   return (
     <>
-      <Box sx={{ display: "flex", justifyContent: "center" }}>
-        <BarChart
-          dataset={data?.getYearlyInvoiceSummary}
-          xAxis={[{ scaleType: "band", dataKey: "year" }]}
-          yAxis={[
-            {
-              scaleType: "linear",
-              dataKey: "balance",
-              valueFormatter: (value: number) =>
-                new Intl.NumberFormat("fr-FR", {
-                  style: "currency",
-                  currency: "EUR",
-                }).format(value),
-            },
-          ]}
-          series={[
-            {
-              dataKey: "total_credits",
-              label: "Crédit",
-              valueFormatter: currencySignValueFormatter,
-            },
-            {
-              dataKey: "total_debits",
-              label: "Débit",
-              valueFormatter: currencySignValueFormatter,
-            },
-            {
-              dataKey: "balance",
-              label: "Balance",
-              valueFormatter: currencySignValueFormatter,
-            },
-          ]}
-          {...chartSetting}
-        />
-      </Box>
+      <article style={{ textAlign: "center" }}>
+        <h2>Etats des exercises annuels</h2>
+        <Box sx={{ display: "flex", justifyContent: "center" }}>
+          <BarChart
+            dataset={data?.getYearlyInvoiceSummary}
+            xAxis={[
+              {
+                scaleType: "band",
+                dataKey: "year",
+                valueFormatter: (value: number) => value.toString(),
+              },
+            ]}
+            yAxis={[
+              {
+                scaleType: "linear",
+                dataKey: "balance",
+                valueFormatter: (value: number) =>
+                  new Intl.NumberFormat("fr-FR", {
+                    style: "currency",
+                    currency: "EUR",
+                  }).format(value),
+              },
+            ]}
+            series={[
+              {
+                dataKey: "total_credits",
+                label: "Crédit",
+                valueFormatter: currencySignValueFormatter,
+              },
+              {
+                dataKey: "total_debits",
+                label: "Débit",
+                valueFormatter: currencySignValueFormatter,
+              },
+              {
+                dataKey: "balance",
+                label: "Balance",
+                valueFormatter: currencySignValueFormatter,
+              },
+            ]}
+            {...chartSetting}
+          />
+        </Box>
+      </article>
     </>
   );
 }

--- a/client/src/components/budgetOverview/YearlyBalance.tsx
+++ b/client/src/components/budgetOverview/YearlyBalance.tsx
@@ -1,0 +1,62 @@
+import { BarChart } from "@mui/x-charts/BarChart";
+import { axisClasses } from "@mui/x-charts/ChartsAxis";
+import { useGetYearlyInvoiceSummaryQuery } from "../../types/graphql-types";
+import { currencySignValueFormatter } from "../../utils/chartsUtils";
+
+const chartSetting = {
+  width: 800,
+  height: 300,
+  margin: { left: 200 },
+  sx: {
+    [`.${axisClasses.left} .${axisClasses.label}`]: {
+      transform: "translate(-20px, 0)",
+    },
+  },
+};
+
+function YearlyBalance() {
+  const { data, loading, error } = useGetYearlyInvoiceSummaryQuery();
+
+  if (loading) return <p>Chargement...</p>;
+  if (error) return <p>Erreur : {error.message}</p>;
+
+  return (
+    <>
+      <BarChart
+        dataset={data?.getYearlyInvoiceSummary}
+        xAxis={[{ scaleType: "band", dataKey: "year" }]}
+        yAxis={[
+          {
+            scaleType: "linear",
+            dataKey: "balance",
+            valueFormatter: (value: number) =>
+              new Intl.NumberFormat("fr-FR", {
+                style: "currency",
+                currency: "EUR",
+              }).format(value),
+          },
+        ]}
+        series={[
+          {
+            dataKey: "total_credits",
+            label: "Crédit",
+            valueFormatter: currencySignValueFormatter,
+          },
+          {
+            dataKey: "total_debits",
+            label: "Débit",
+            valueFormatter: currencySignValueFormatter,
+          },
+          {
+            dataKey: "balance",
+            label: "Balance",
+            valueFormatter: currencySignValueFormatter,
+          },
+        ]}
+        {...chartSetting}
+      />
+    </>
+  );
+}
+
+export default YearlyBalance;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -16,7 +16,7 @@ import ManageCategory from "./pages/accountant/category/ManageCategory.tsx";
 import Invoice from "./pages/commission/Invoice.tsx";
 import Login from "./pages/Login.tsx";
 import BankAccount from "./pages/administrator/bank/BankAccount.tsx";
-import BudgetOverview from "./components/budgetOverview/BudgetOverview.tsx";
+import HomePageAdministrator from "./pages/administrator/HomePageAdministrator.tsx";
 import HomePageAccountant from "./pages/accountant/HomePageAccountant.tsx";
 import SetupBudgets from "./pages/administrator/exercise/SetupBudgets.tsx";
 import InvoiceOverview from "./pages/administrator/invoice/InvoiceOverview.tsx";
@@ -52,7 +52,7 @@ const router = createBrowserRouter([
         children: [
           {
             index: true,
-            element: <BudgetOverview />,
+            element: <HomePageAdministrator />,
           },
           {
             path: "invoiceOverview",

--- a/client/src/pages/administrator/HomePageAdministrator.tsx
+++ b/client/src/pages/administrator/HomePageAdministrator.tsx
@@ -1,0 +1,13 @@
+import BudgetOverview from "../../components/budgetOverview/BudgetOverview";
+import YearlyBalance from "../../components/budgetOverview/YearlyBalance";
+
+function HomePageAdministrator() {
+  return (
+    <>
+      <BudgetOverview />
+      <YearlyBalance />
+    </>
+  );
+}
+
+export default HomePageAdministrator;

--- a/client/src/schema/queries.ts
+++ b/client/src/schema/queries.ts
@@ -412,3 +412,14 @@ export const GET_EXERCISE_BY_ID = gql`
     }
   }
 `;
+
+export const GET_YEARLY_BALANCES = gql`
+  query GetYearlyInvoiceSummary {
+    getYearlyInvoiceSummary {
+      year
+      total_debits
+      total_credits
+      balance
+    }
+  }
+`;

--- a/client/src/types/graphql-types.ts
+++ b/client/src/types/graphql-types.ts
@@ -142,6 +142,14 @@ export type Invoice = {
   vat: Vat;
 };
 
+export type InvoiceYearlySummary = {
+  __typename?: "InvoiceYearlySummary";
+  balance: Scalars["Float"]["output"];
+  total_credits: Scalars["Float"]["output"];
+  total_debits: Scalars["Float"]["output"];
+  year: Scalars["Int"]["output"];
+};
+
 export type LoginResponse = {
   __typename?: "LoginResponse";
   email: Scalars["String"]["output"];
@@ -296,6 +304,7 @@ export type Query = {
   getUserById: User;
   getUsers: PaginatedUsers;
   getVats: Array<Vat>;
+  getYearlyInvoiceSummary: Array<InvoiceYearlySummary>;
 };
 
 export type QueryGetCurrentBudgetByCommissionIdArgs = {
@@ -1050,6 +1059,21 @@ export type GetExerciseByIdQuery = {
     start_date: string;
     end_date: string;
   };
+};
+
+export type GetYearlyInvoiceSummaryQueryVariables = Exact<{
+  [key: string]: never;
+}>;
+
+export type GetYearlyInvoiceSummaryQuery = {
+  __typename?: "Query";
+  getYearlyInvoiceSummary: Array<{
+    __typename?: "InvoiceYearlySummary";
+    year: number;
+    total_debits: number;
+    total_credits: number;
+    balance: number;
+  }>;
 };
 
 export const AddCategoryDocument = gql`
@@ -3775,6 +3799,86 @@ export type GetExerciseByIdQueryResult = Apollo.QueryResult<
   GetExerciseByIdQuery,
   GetExerciseByIdQueryVariables
 >;
+export const GetYearlyInvoiceSummaryDocument = gql`
+  query GetYearlyInvoiceSummary {
+    getYearlyInvoiceSummary {
+      year
+      total_debits
+      total_credits
+      balance
+    }
+  }
+`;
+
+/**
+ * __useGetYearlyInvoiceSummaryQuery__
+ *
+ * To run a query within a React component, call `useGetYearlyInvoiceSummaryQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetYearlyInvoiceSummaryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetYearlyInvoiceSummaryQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGetYearlyInvoiceSummaryQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    GetYearlyInvoiceSummaryQuery,
+    GetYearlyInvoiceSummaryQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GetYearlyInvoiceSummaryQuery,
+    GetYearlyInvoiceSummaryQueryVariables
+  >(GetYearlyInvoiceSummaryDocument, options);
+}
+export function useGetYearlyInvoiceSummaryLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetYearlyInvoiceSummaryQuery,
+    GetYearlyInvoiceSummaryQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetYearlyInvoiceSummaryQuery,
+    GetYearlyInvoiceSummaryQueryVariables
+  >(GetYearlyInvoiceSummaryDocument, options);
+}
+export function useGetYearlyInvoiceSummarySuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetYearlyInvoiceSummaryQuery,
+        GetYearlyInvoiceSummaryQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GetYearlyInvoiceSummaryQuery,
+    GetYearlyInvoiceSummaryQueryVariables
+  >(GetYearlyInvoiceSummaryDocument, options);
+}
+export type GetYearlyInvoiceSummaryQueryHookResult = ReturnType<
+  typeof useGetYearlyInvoiceSummaryQuery
+>;
+export type GetYearlyInvoiceSummaryLazyQueryHookResult = ReturnType<
+  typeof useGetYearlyInvoiceSummaryLazyQuery
+>;
+export type GetYearlyInvoiceSummarySuspenseQueryHookResult = ReturnType<
+  typeof useGetYearlyInvoiceSummarySuspenseQuery
+>;
+export type GetYearlyInvoiceSummaryQueryResult = Apollo.QueryResult<
+  GetYearlyInvoiceSummaryQuery,
+  GetYearlyInvoiceSummaryQueryVariables
+>;
 export const namedOperations = {
   Query: {
     GetUsers: "GetUsers",
@@ -3796,6 +3900,7 @@ export const namedOperations = {
     GetExerciseBudgets: "GetExerciseBudgets",
     GetInvoicesByExercise: "GetInvoicesByExercise",
     GetExerciseById: "GetExerciseById",
+    GetYearlyInvoiceSummary: "GetYearlyInvoiceSummary",
   },
   Mutation: {
     AddCategory: "AddCategory",

--- a/client/src/utils/chartsUtils.ts
+++ b/client/src/utils/chartsUtils.ts
@@ -1,0 +1,3 @@
+export function currencySignValueFormatter(value: number | null) {
+  return `${value}€`;
+}


### PR DESCRIPTION
During the seeding, the bank accounts balances are now filled. This is the query:
```
UPDATE bank_account
      SET balance = subquery.balance
      FROM (
          SELECT
              "bankAccountId",
              SUM(CASE WHEN "creditDebitId" = 1 THEN "amount_with_vat" ELSE -"amount_with_vat" END) AS balance
          FROM
              invoice
          GROUP BY
              "bankAccountId"
      ) AS subquery
      WHERE id = subquery."bankAccountId";
```

A new chart has been added for the administrator overview. It shows the historical yearly balances:

![image](https://github.com/user-attachments/assets/03bb09f6-56a5-4d3b-a6d9-6936966d7b5f)

![image](https://github.com/user-attachments/assets/0e784585-f0c5-45a2-9028-efcaaa749ee2)

