### PR TITLE
fix/Client_add_bank_account_before_validate_invoice

### DIFF
--- a/client/src/components/addBankAccount/AddBankAccount.tsx
+++ b/client/src/components/addBankAccount/AddBankAccount.tsx
@@ -6,6 +6,8 @@ interface AddBankAccountProps {
   invoiceId: number;
   selectedBank: string;
   setSelectedBank: (value: string) => void;
+  setSelectedBankAccountId: (value: string) => void;
+  selectedBankAccountId: string;
   banks: Bank[];
 }
 
@@ -13,6 +15,8 @@ function AddBankAccount({
   selectedBank,
   setSelectedBank,
   banks,
+  setSelectedBankAccountId,
+  selectedBankAccountId,
 }: AddBankAccountProps) {
   return (
     <Grid
@@ -78,6 +82,8 @@ function AddBankAccount({
                 name="numéro de compte"
                 id="account"
                 aria-label="Sélectionnez le numéro de compte"
+                value={selectedBankAccountId}
+                onChange={(e) => setSelectedBankAccountId(e.target.value)}
                 style={{
                   width: "100%",
                   padding: "0.5rem",

--- a/client/src/components/addCategory/AddCategory.tsx
+++ b/client/src/components/addCategory/AddCategory.tsx
@@ -172,6 +172,7 @@ function AddCategory() {
                 display: "block",
                 margin: "0 auto",
                 marginTop: 2,
+                fontWeight: "bold",
               }}
               disabled={loading}
             >

--- a/client/src/pages/accountant/DetailInvoice.tsx
+++ b/client/src/pages/accountant/DetailInvoice.tsx
@@ -47,6 +47,9 @@ function DetailInvoice() {
   });
 
   const [selectedBank, setSelectedBank] = useState<string | "">("");
+  const [selectedBankAccountId, setSelectedBankAccountId] = useState<
+    string | ""
+  >("");
   const [banks, setBanks] = useState<Bank[]>([]);
 
   const [
@@ -140,12 +143,18 @@ function DetailInvoice() {
   const invoice = data.getInvoiceById;
 
   const handleValidateInvoice = async () => {
-    const selectedBankAccount = banks?.find(
-      (bank) => String(bank.id) === selectedBank,
-    )?.bankAccounts?.[0];
+    if (!selectedBank) {
+      notifyError("Veuillez sélectionner une banque");
+      return;
+    }
 
-    const bankAccountId = selectedBankAccount?.id
-      ? Number(selectedBankAccount.id)
+    if (!selectedBankAccountId) {
+      notifyError("Veuillez sélectionner un compte bancaire");
+      return;
+    }
+
+    const bankAccountId = selectedBankAccountId
+      ? Number(selectedBankAccountId)
       : null;
 
     if (!bankAccountId) {
@@ -426,6 +435,8 @@ function DetailInvoice() {
               invoiceId={invoice.id}
               selectedBank={selectedBank}
               setSelectedBank={setSelectedBank}
+              selectedBankAccountId={selectedBankAccountId}
+              setSelectedBankAccountId={setSelectedBankAccountId}
               banks={banks}
             />
             <Grid


### PR DESCRIPTION
I noticed a wrong validation of input in frontend for the addition of a bank account. In fact, this validation only took into account the first bank account of each bank.

const selectedBankAccount = banks?.find(
      (bank) => String(bank.id) === selectedBank,
    )?.bankAccounts?.[0];
    
I corrected and revised my logic by setting a state for the bank account id and value and onChange parameters for the bank account select.